### PR TITLE
Add versioning to Sqltable, and schema change sunit tests for Sqltable

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,72 @@
+#  Project Design Document: Concurrent Schema Change
+
+## Overview
+
+Each table in a DBMS has a schema, which specifies how many columns are in the table, and the constrains on each column (type, nullable, default value). A schema change can involving adding/dropping columns, or updating column constraints. Many DBMSs (PostgreSQL, SQLite, and RocksDB) block the table when they perform a schema change on a table. This causes the table to be unavailable for a considerable duration, which is undesirable for systems requiring high availability. Terrier currently does not support schema change. 
+
+The goal of this project is to add schema change functionality to Terrier, and do it in a non-blocking, lazy way. The idea is to store a separate Datatable for each schema version, and do it Our goals are:
+
+75%: Support lazy add/drop column and arbitrary number of schema versions      (mostly done, need to update the upper level of the system and the catalog, and pass benchmarks)
+
+100%: Do background migration of tupleslots. Support GC of old schema versions and datatables. 
+
+125%: Support unsafe schema changes, which includes updating type, nullable, or default value status of columns.
+
+150%: Codegen layer to precompile tuple transformations.
+
+## Scope
+
+Our project will mainly modify Sqltable and Catalog. Sqltable will be modified to handle multiple datatables . The datatables are transparent to the users of Sqltable,  who view Sqltable as a logical table with multiple versions. All functions in the Sqltable API (such as insert/delete/update/scan/begin/end/projectmapforoids) are augmented with an extra argument, layout_version. layout_version tells Sqltable which version of the table the function is targeted to.
+
+We will modify the Catalog to support the functions DatabaseCatalog::UpdateSchema()/GetSchema()/GetConstraints(). The catalog will be store information about the schema versions of each Sqltable, and use the timestamp of a transaction to infer the correct schema version of each Sqltable the transaction accesses. 
+
+We will not change the API of Datatable, and make only minor additions to it. For convenience, within each Datatable we store its corresponding version, default value map, column id to oid map, and column oid to id map (explained below). Similarly, we will not be touching Tupleslots, Rawblocks, or Index.
+
+We will also make minor changes to upper levels of Terrier, such the execution layer (e.g. storage_interface.cpp). 
+
+## Architectural Design
+
+Each Sqltable has a separate version number counter, managed by the catalog. Each Sqltable starts out with version number 0, and manages a single datatable. When UpdateSchema() is called, the version number is incremented, and we create a new datatable via SqlTable::CreateTable(), which is the intended location for all tuples under the new schema. Note that within a Sqltable, each datatable uniquely corresponds to a version number and a schema, both of which never change. Therefore, in each datatable, we store its version number and a map specifying the default values of columns in its schema. 
+
+To manage multiple datatables, each Sqltable keeps a ordered map from version number to datatable. We will make this map 
+
+To do an SQL query such as updating a tuple, a transaction first uses the index on Sqltable to find the tupleslot of the tuple (note that when we update the index when migrating tupeslots). We can get the raw block from the top 44 bits of the tupleslot, and the raw block has reference to the datatable of the tupleslot.  
+
+We store within each datatable a layout_version. Note that apart from the 
+
+In Sqltable, we use a concurrent hashmap to map layout_version to datatables.
+
+## Design Rationale
+
+#### Map or vector of datatables? 
+
+Within Sqltable, we can either use a ordered concurrent map of version number to datatable, or use a vector of datatables (index i of vector corresponds to datatable with version number i) augmented with locks.  We conjecture that using a vector will be faster than a map. One potential problem with vectors is how to make it work with GC of old versions, and recovery. One potential problem with using Terrier's concurrent_map.h, which is a wrapper around tbb_concurrent_unordered_map, is that it is unordered (we need order for scan) and unsafe for concurrent deletes (useful for GC of old versions).
+
+For now we are just using a std::map for single-threaded implementation, and we will revisit this decision later.
+
+#### When to perform background migration and GC of old versions?
+
+When we are sure that no transactions will ever access the schema version represented by an old datatable(inferring from low_watermark of transaction timestamps), we can safely GC the outdated datatable. However, since we do lazy migration, if most tuples in a datatable is not updated after a schema change, they will still be in the outdated datatable, and we can read and access them from the outdated datatable. In this case, it might be quite expensive to GC the outdated datatable, since we need to first migrate all its tuples to newer datatables. It seems that doing background migrations conservatively is good for read-heavy workloads, and doing background migrations aggresively might be good for update-heavy workloads interleaved with schema changes.  
+
+Our current decision is to use a threshold to decide whether to do background migration: once the amount of tuples in an outdated datatable drops below the threshold, we start a background thread to migrate its tuples and GC the datatable when we're done.
+
+#### Should we do migration on reads?
+
+This is related to the above decision on GC. Currently, we only migrate tuples on Sqltable::update, if the tuple belongs to a newer datatable. Another policy is to also do migration on reads: after reading a tuple that belongs to a newer datatable (in Sqltable::select or Sqltable::scan), we migrate it to the new datatable before reading it. The benefit of migration on reads is: if we read a tuple from an outdated table multiple times,  transforming the tuple to its newest schema every time can be costly. With migration on reads, we need to do tuple transformation only once. Migration on reads  works well with aggresive migration. However, migration on reads might need to take write locks to do the migration, which can considerably slow down throughput of reads.
+
+Our current decision is to not do migration on reads, since it might affect throughput. We will revisit this decision when we finish implementing GC and start benchmarking throughput.
+
+## Testing Plan
+
+First, we will write single-threaded unit tests in sql_table_test.cpp that tests schema changes. Currently, we wrote the testing framework, and have a test that tests inserting and a test that updates the schema by adding a single column. We will add more unit tests that add and drop multiple columns for multiple rounds. We will test that Sqltable::insert/delete/update/scan still works properly, after our change.
+
+We will also write benchmarks that concurrently performs schema updates with normal Sqltable queries. This is mainly to test the correctness of our approach in the multi-threaded case, and can test the correctness of our changes to the catalog and storage layer. We will also use benchmarks with different workloads (read-heavy, update-heavy, eg.) to test the performance under schema changes.
+
+Finally, as a stretch goal, we can integrate the Pantha Rei Schema Evolution Benchmark, which contains over 4.5 years of schema changes in Wikipedia’s history, and use this real world benchmark to test the throughput and memory usage of our non-blocking schema change implementation.
+
+## Trade-offs and Potential Problems
+
+## Future Work
+
+One optimization is to precompile the tuple transformations.  
+

--- a/src/catalog/database_catalog.cpp
+++ b/src/catalog/database_catalog.cpp
@@ -1194,7 +1194,7 @@ bool DatabaseCatalog::SetClassPointer(const common::ManagedPointer<transaction::
 
   // Finish
   delete[] buffer;
-  return classes_->Update(txn, update_redo);
+  return classes_->Update(txn, update_redo).first;
 }
 
 bool DatabaseCatalog::SetIndexPointer(const common::ManagedPointer<transaction::TransactionContext> txn,
@@ -1581,7 +1581,7 @@ bool DatabaseCatalog::CreateIndexEntry(const common::ManagedPointer<transaction:
 
   update_redo->SetTupleSlot(class_tuple_slot);
   *reinterpret_cast<IndexSchema **>(update_pr->AccessForceNotNull(0)) = new_schema;
-  auto UNUSED_ATTRIBUTE res = classes_->Update(txn, update_redo);
+  auto UNUSED_ATTRIBUTE res = classes_->Update(txn, update_redo).first;
   TERRIER_ASSERT(res, "Updating an uncommitted insert should not fail");
 
   return true;
@@ -1860,7 +1860,7 @@ bool DatabaseCatalog::CreateTableEntry(const common::ManagedPointer<transaction:
 
   update_redo->SetTupleSlot(tuple_slot);
   *reinterpret_cast<Schema **>(update_pr->AccessForceNotNull(0)) = new_schema;
-  auto UNUSED_ATTRIBUTE res = classes_->Update(txn, update_redo);
+  auto UNUSED_ATTRIBUTE res = classes_->Update(txn, update_redo).first;
   TERRIER_ASSERT(res, "Updating an uncommitted insert should not fail");
 
   return true;

--- a/src/execution/sql/storage_interface.cpp
+++ b/src/execution/sql/storage_interface.cpp
@@ -62,7 +62,7 @@ bool StorageInterface::TableDelete(storage::TupleSlot table_tuple_slot) {
 bool StorageInterface::TableUpdate(storage::TupleSlot table_tuple_slot) {
   exec_ctx_->RowsAffected()++;  // believe this should only happen in root plan nodes, so should reflect count of query
   table_redo_->SetTupleSlot(table_tuple_slot);
-  return table_->Update(exec_ctx_->GetTxn(), table_redo_);
+  return table_->Update(exec_ctx_->GetTxn(), table_redo_).first;
 }
 
 bool StorageInterface::IndexInsert() {

--- a/src/include/storage/data_table.h
+++ b/src/include/storage/data_table.h
@@ -248,7 +248,7 @@ class DataTable {
   // Singly-linked list for tables with different version?
   std::atomic<DataTable *> next_table_ = nullptr;
   // Or pointer to the SqlTable which has information about different versions?
-  const SqlTable* sql_table_ = nullptr;
+  const SqlTable *sql_table_ = nullptr;
 
   // TODO(Tianyu): For now, on insertion, we simply sequentially go through a block and allocate a
   // new one when the current one is full. Needless to say, we will need to revisit this when extending GC to handle
@@ -268,7 +268,6 @@ class DataTable {
   // This function uses header_latch_ to ensure correctness
   void CheckMoveHead(std::list<RawBlock *>::iterator block);
   mutable DataTableCounter data_table_counter_;
-
 
   // A templatized version for select, so that we can use the same code for both row and column access.
   // the method is explicitly instantiated for ProjectedRow and ProjectedColumns::RowView

--- a/src/include/storage/data_table.h
+++ b/src/include/storage/data_table.h
@@ -241,6 +241,12 @@ class DataTable {
   const layout_version_t layout_version_;
   const TupleAccessStrategy accessor_;
 
+  // TODO(Schema-Change)
+  // Singly-linked list for tables with different version?
+  std::atomic<DataTable *> next_table_ = nullptr;
+  // Or pointer to the SqlTable which has information about different versions?
+  const SqlTable* sql_table_ = nullptr;
+
   // TODO(Tianyu): For now, on insertion, we simply sequentially go through a block and allocate a
   // new one when the current one is full. Needless to say, we will need to revisit this when extending GC to handle
   // deleted tuples and recycle slots
@@ -259,6 +265,7 @@ class DataTable {
   // This function uses header_latch_ to ensure correctness
   void CheckMoveHead(std::list<RawBlock *>::iterator block);
   mutable DataTableCounter data_table_counter_;
+
 
   // A templatized version for select, so that we can use the same code for both row and column access.
   // the method is explicitly instantiated for ProjectedRow and ProjectedColumns::RowView

--- a/src/include/storage/data_table.h
+++ b/src/include/storage/data_table.h
@@ -143,20 +143,23 @@ class DataTable {
   // save a point of scan and come back to it later?
   // Alternatively, we can provide an easy wrapper that takes in a const SlotIterator & and returns a SlotIterator,
   // just like the ++i and i++ dichotomy.
-  /**
-   * Sequentially scans the table starting from the given iterator(inclusive) and materializes as many tuples as would
-   * fit into the given buffer, as visible to the transaction given, according to the format described by the given
-   * output buffer. The tuples materialized are guaranteed to be visible and valid, and the function makes best effort
-   * to fill the buffer, unless there are no more tuples. The given iterator is mutated to point to one slot passed the
-   * last slot scanned in the invocation.
-   *
-   * @param txn the calling transaction
-   * @param start_pos iterator to the starting location for the sequential scan
-   * @param out_buffer output buffer. The object should already contain projection list information. This buffer is
-   *                   always cleared of old values.
-   */
-  void Scan(common::ManagedPointer<transaction::TransactionContext> txn, SlotIterator *start_pos,
-            ProjectedColumns *out_buffer) const;
+  // /**
+  //  * Sequentially scans the table starting from the given iterator(inclusive) and materializes as many tuples as
+  //  would
+  //  * fit into the given buffer, as visible to the transaction given, according to the format described by the given
+  //  * output buffer. The tuples materialized are guaranteed to be visible and valid, and the function makes best
+  //  effort
+  //  * to fill the buffer, unless there are no more tuples. The given iterator is mutated to point to one slot passed
+  //  the
+  //  * last slot scanned in the invocation.
+  //  *
+  //  * @param txn the calling transaction
+  //  * @param start_pos iterator to the starting location for the sequential scan
+  //  * @param out_buffer output buffer. The object should already contain projection list information. This buffer is
+  //  *                   always cleared of old values.
+  //  */
+  // void Scan(common::ManagedPointer<transaction::TransactionContext> txn, SlotIterator *start_pos,
+  //           ProjectedColumns *out_buffer) const;
 
   /**
    * @return the first tuple slot contained in the data table

--- a/src/include/storage/data_table.h
+++ b/src/include/storage/data_table.h
@@ -19,6 +19,7 @@ class TransactionManager;
 }  // namespace terrier::transaction
 
 namespace terrier::storage {
+class SqlTable;
 
 namespace index {
 class Index;
@@ -236,6 +237,8 @@ class DataTable {
   // The block compactor elides transactional protection in the gather/compression phase and
   // needs raw access to the underlying table.
   friend class BlockCompactor;
+  // The SqlTable needs to access the layout version
+  friend class SqlTable;
 
   const common::ManagedPointer<BlockStore> block_store_;
   const layout_version_t layout_version_;

--- a/src/include/storage/data_table.h
+++ b/src/include/storage/data_table.h
@@ -143,23 +143,23 @@ class DataTable {
   // save a point of scan and come back to it later?
   // Alternatively, we can provide an easy wrapper that takes in a const SlotIterator & and returns a SlotIterator,
   // just like the ++i and i++ dichotomy.
-  // /**
-  //  * Sequentially scans the table starting from the given iterator(inclusive) and materializes as many tuples as
-  //  would
-  //  * fit into the given buffer, as visible to the transaction given, according to the format described by the given
-  //  * output buffer. The tuples materialized are guaranteed to be visible and valid, and the function makes best
-  //  effort
-  //  * to fill the buffer, unless there are no more tuples. The given iterator is mutated to point to one slot passed
-  //  the
-  //  * last slot scanned in the invocation.
-  //  *
-  //  * @param txn the calling transaction
-  //  * @param start_pos iterator to the starting location for the sequential scan
-  //  * @param out_buffer output buffer. The object should already contain projection list information. This buffer is
-  //  *                   always cleared of old values.
-  //  */
-  // void Scan(common::ManagedPointer<transaction::TransactionContext> txn, SlotIterator *start_pos,
-  //           ProjectedColumns *out_buffer) const;
+  /**
+   * Sequentially scans the table starting from the given iterator(inclusive) and materializes as many tuples as
+   would
+   * fit into the given buffer, as visible to the transaction given, according to the format described by the given
+   * output buffer. The tuples materialized are guaranteed to be visible and valid, and the function makes best
+   effort
+   * to fill the buffer, unless there are no more tuples. The given iterator is mutated to point to one slot passed
+   the
+   * last slot scanned in the invocation.
+   *
+   * @param txn the calling transaction
+   * @param start_pos iterator to the starting location for the sequential scan
+   * @param out_buffer output buffer. The object should already contain projection list information. This buffer is
+   *                   always cleared of old values.
+   */
+  void Scan(common::ManagedPointer<transaction::TransactionContext> txn, SlotIterator *start_pos,
+            ProjectedColumns *out_buffer) const;
 
   /**
    * @return the first tuple slot contained in the data table

--- a/src/include/storage/sql_table.h
+++ b/src/include/storage/sql_table.h
@@ -87,8 +87,8 @@ class SqlTable {
    * @param layout_version Schema version the current querying transaction should see
    * @return true if successful, false otherwise
    */
-  bool Update(common::ManagedPointer<transaction::TransactionContext> txn, RedoRecord *redo,
-              layout_version_t layout_version = layout_version_t{0}) const;
+  std::pair<bool, TupleSlot> Update(const common::ManagedPointer <TransactionContext> txn, RedoRecord *const redo,
+                                    layout_version_t layout_version = layout_version_t{0}) const;
 
   /**
    * Inserts a tuple, as given in the redo, and return the slot allocated for the tuple. StageWrite must have been

--- a/src/include/storage/sql_table.h
+++ b/src/include/storage/sql_table.h
@@ -41,6 +41,7 @@ class SqlTable {
     //  It only works for adding and dropping columns, but not modifying type/constraint/default of the column
     //  Consider storing forward and backward delta of the schema change maybe in the future
     ColumnIdToOidMap column_id_to_oid_map_;
+    common::ManagedPointer<const catalog::Schema> schema_;
   };
 
  public:

--- a/src/include/storage/sql_table.h
+++ b/src/include/storage/sql_table.h
@@ -31,8 +31,6 @@ namespace terrier::storage {
  * translation to BlockLayout and col_id_t to talk to the DataTable and other areas of the storage layer.
  */
 class SqlTable {
-  using DefaultValueMap = std::unordered_map<col_id_t, common::ManagedPointer<const parser::AbstractExpression>>;
-
   /**
    * Contains all of the metadata the SqlTable needs to reference a DataTable. We shouldn't ever have to expose these
    * concepts to anyone above the SqlTable level. If you find yourself wanting to return BlockLayout or col_id_t above

--- a/src/include/storage/sql_table.h
+++ b/src/include/storage/sql_table.h
@@ -42,6 +42,7 @@ class SqlTable {
     //  Consider storing forward and backward delta of the schema change maybe in the future
     ColumnIdToOidMap column_id_to_oid_map_;
     common::ManagedPointer<const catalog::Schema> schema_;
+    DefaultValueMap default_value_map_;
   };
 
  public:
@@ -58,7 +59,7 @@ class SqlTable {
    * Destructs a SqlTable, frees all its members.
    */
   ~SqlTable() {
-    for (const auto &it :tables_) delete it.second.data_table_;
+    for (const auto &it : tables_) delete it.second.data_table_;
   }
 
   /**
@@ -69,8 +70,8 @@ class SqlTable {
    * @param out_buffer output buffer. The object should already contain projection list information. @see ProjectedRow.
    * @return true if tuple is visible to this txn and ProjectedRow has been populated, false otherwise
    */
-  bool Select(common::ManagedPointer <transaction::TransactionContext> txn,
-              layout_version_t layout_version, TupleSlot slot, ProjectedRow * out_buffer) const;
+  bool Select(common::ManagedPointer<transaction::TransactionContext> txn, layout_version_t layout_version,
+              TupleSlot slot, ProjectedRow *out_buffer) const;
 
   /**
    * Update the tuple according to the redo buffer given. StageWrite must have been called as well in order for the
@@ -81,8 +82,8 @@ class SqlTable {
    * TupleSlot in this RedoRecord must be set to the intended tuple.
    * @return true if successful, false otherwise
    */
-  bool Update(common::ManagedPointer <transaction::TransactionContext> txn,
-              layout_version_t layout_version, RedoRecord * redo) const;
+  bool Update(common::ManagedPointer<transaction::TransactionContext> txn, layout_version_t layout_version,
+              RedoRecord *redo) const;
 
   /**
    * Inserts a tuple, as given in the redo, and return the slot allocated for the tuple. StageWrite must have been
@@ -92,8 +93,7 @@ class SqlTable {
    * @param redo after-image of the inserted tuple.
    * @return TupleSlot for the inserted tuple
    */
-  TupleSlot Insert(const common::ManagedPointer <transaction::TransactionContext> txn,
-                   layout_version_t layout_version,
+  TupleSlot Insert(const common::ManagedPointer<transaction::TransactionContext> txn, layout_version_t layout_version,
                    RedoRecord *const redo) const {
     TERRIER_ASSERT(redo->GetTupleSlot() == TupleSlot(nullptr, 0), "TupleSlot was set in this RedoRecord.");
     TERRIER_ASSERT(redo == reinterpret_cast<LogRecord *>(txn->redo_buffer_.LastRecord())
@@ -111,7 +111,8 @@ class SqlTable {
    * @param slot the slot of the tuple to delete
    * @return true if successful, false otherwise
    */
-  bool Delete(const common::ManagedPointer<transaction::TransactionContext> txn, layout_version_t layout_version, const TupleSlot slot) {
+  bool Delete(const common::ManagedPointer<transaction::TransactionContext> txn, layout_version_t layout_version,
+              const TupleSlot slot) {
     TERRIER_ASSERT(txn->redo_buffer_.LastRecord() != nullptr,
                    "The RedoBuffer is empty even though StageDelete should have been called.");
     TERRIER_ASSERT(
@@ -164,14 +165,16 @@ class SqlTable {
    * @param: layout_version the last version I should be able to see
    * @return one past the last tuple slot contained in the underlying DataTable
    */
-  DataTable::SlotIterator end(layout_version_t layout_version) const { return table_.tables_.at[layout_version]->end(); }  // NOLINT for STL name compability
+  DataTable::SlotIterator end(layout_version_t layout_version) const {
+    return table_.tables_.at[layout_version]->end();
+  }  // NOLINT for STL name compability
 
   // TODO(Schema-Change): add projection considering table
-  //  We might have to seperate the use cases here: one implementation that does not expect schema chnage at all, one does.
-  //  In many cases, this function is called not in transactional context (thus layout_version not really relevant).
-  //  For example, in TPCC, the worker will pre-allocate a buffer with size equal to the projectedrow's size.
-  //  For the version that does expect a version change: we can save the col_oids and the reference to the SqlTable in the
-  //  ProjRow(Colum)Initlizer, and only later when a transactional context is known, we materialize this initializer
+  //  We might have to seperate the use cases here: one implementation that does not expect schema chnage at all, one
+  //  does. In many cases, this function is called not in transactional context (thus layout_version not really
+  //  relevant). For example, in TPCC, the worker will pre-allocate a buffer with size equal to the projectedrow's size.
+  //  For the version that does expect a version change: we can save the col_oids and the reference to the SqlTable in
+  //  the ProjRow(Colum)Initlizer, and only later when a transactional context is known, we materialize this initializer
   //  with the correct layout_version
   /**
    * Generates an ProjectedColumnsInitializer for the execution layer to use. This performs the translation from col_oid
@@ -191,7 +194,6 @@ class SqlTable {
     return ProjectedColumnsInitializer(table_.layout_, col_ids, max_tuples);
   }
 
-
   /**
    * Generates an ProjectedRowInitializer for the execution layer to use. This performs the translation from col_oid to
    * col_id for the Initializer's constructor so that the execution layer doesn't need to know anything about col_id.
@@ -199,7 +201,8 @@ class SqlTable {
    * @return initializer to create ProjectedRow
    * @warning col_oids must be a set (no repeats)
    */
-  ProjectedRowInitializer InitializerForProjectedRow(const std::vector<catalog::col_oid_t> &col_oids, layout_version_t layout_version) const {
+  ProjectedRowInitializer InitializerForProjectedRow(const std::vector<catalog::col_oid_t> &col_oids,
+                                                     layout_version_t layout_version) const {
     // TODO(Schema-Change): this function is called for calculating the optimal layout of the columns
     //  (so they are not stored in logical order).
     //  This should not be using the inside data, but only the layout/column information.
@@ -234,16 +237,19 @@ class SqlTable {
   // Used orderred map for traversing data table that are less or equal to curr version
   std::map<layout_version_t, DataTableVersion> tables_;
 
-  void AlignHeaderToVersion(ProjectedRow * out_buffer, const DataTableVersion &tuple_version,
-                            const DataTableVersion &desired_version, col_id_t *cached_ori_header,
-                            std::vector<catalog::col_oid_t>* missing_cols) const;
+  // TODO(Schema-Change): Make the below two functions static maybe
+  void AlignHeaderToVersion(ProjectedRow *out_buffer, const DataTableVersion &tuple_version,
+                            const DataTableVersion &desired_version, col_id_t *cached_ori_header) const;
+
+  void FillMissingColumns(ProjectedRow *out_buffer, const DataTableVersion &desired_version) const;
 
   /**
    * Given a set of col_oids, return a vector of corresponding col_ids to use for ProjectionInitialization
    * @param col_oids set of col_oids, they must be in the table's ColumnMap
    * @return vector of col_ids for these col_oids
    */
-  std::vector<col_id_t> ColIdsForOids(const std::vector<catalog::col_oid_t> &col_oids, layout_version_t layout_version) const;
+  std::vector<col_id_t> ColIdsForOids(const std::vector<catalog::col_oid_t> &col_oids,
+                                      layout_version_t layout_version) const;
 
   /**
    * @warning This function is expensive to call and should be used with caution and sparingly.

--- a/src/include/storage/sql_table.h
+++ b/src/include/storage/sql_table.h
@@ -300,9 +300,9 @@ class SqlTable {
 
   /**
    * Creates a new datatble version given the schema and version number
-   * @param schema Schema of
-   * @param store
-   * @param version
+   * @param schema the initial Schema of this SqlTable
+   * @param store the Block store to use.
+   * @param version Schema version of the created/updated table version
    * @return DataTableVersion
    */
   DataTableVersion CreateTable(common::ManagedPointer<const catalog::Schema> schema,

--- a/src/include/storage/sql_table.h
+++ b/src/include/storage/sql_table.h
@@ -140,17 +140,16 @@ class SqlTable {
    * output buffer. The tuples materialized are guaranteed to be visible and valid, and the function makes best effort
    * to fill the buffer, unless there are no more tuples. The given iterator is mutated to point to one slot past the
    * last slot scanned in the invocation.
-   *
+   * @warning a tuple inserted early than start_pos might appear in the scan (by migrating into a later version schema
+   * datatable so the ordering of the scanning is not strictly defined here. However, if start_pos is obtained through
+   * SqlTable::begin(), the results will always contain the same tuples
    * @param txn the calling transaction
-   * @param start_pos iterator to the starting location for the sequential scan
+   * @param start_pos iterator to the starting location for the sequential scan.
    * @param out_buffer output buffer. The object should already contain projection list information. This buffer is
    *                   always cleared of old values.
    */
   void Scan(const common::ManagedPointer<transaction::TransactionContext> txn, DataTable::SlotIterator *const start_pos,
-            ProjectedColumns *const out_buffer) const {
-    // TODO(Schema-Change): among all relavant datatables.
-    return table_.data_table_->Scan(txn, start_pos, out_buffer);
-  }
+            ProjectedColumns *const out_buffer, const layout_version_t layout_version) const;
 
   /**
    * Creates a new tableversion given a schema. Conccurent UpdateSchema is synchronized at the Catalog table.

--- a/src/include/storage/sql_table.h
+++ b/src/include/storage/sql_table.h
@@ -244,6 +244,16 @@ class SqlTable {
   ProjectionMap ProjectionMapForOids(const std::vector<catalog::col_oid_t> &col_oids,
                                      layout_version_t layout_version = layout_version_t{0});
 
+  /**
+   * Returns the layout version of a datatable.
+   * @warning This is only used for testing purpose
+   * @param layout_version
+   * @return
+   */
+  const BlockLayout &GetBlockLayout(layout_version_t layout_version = layout_version_t{0}) {
+    return tables_.at(layout_version).layout_;
+  }
+
  private:
   friend class RecoveryManager;  // Needs access to OID and ID mappings
   friend class terrier::RandomSqlTableTransaction;

--- a/src/include/storage/storage_defs.h
+++ b/src/include/storage/storage_defs.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <parser/expression/abstract_expression.h>
 #include <algorithm>
 #include <functional>
 #include <ostream>
@@ -205,10 +204,6 @@ using ColumnOidToIdMap = std::unordered_map<catalog::col_oid_t, col_id_t>;
  * Used by SqlTable to map between col_ids in BlockLayout and col_oids in Schema
  */
 using ColumnIdToOidMap = std::unordered_map<col_id_t, catalog::col_oid_t>;
-/*
- * Used by SqlTable to map between col_ids in BlockLayout and default values in Schema
- */
-using DefaultValueMap = std::unordered_map<col_id_t, common::ManagedPointer<parser::AbstractExpression>>;
 /**
  * Used by execution and storage layers to map between col_oids and offsets within a ProjectedRow
  */

--- a/src/include/storage/storage_defs.h
+++ b/src/include/storage/storage_defs.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <parser/expression/abstract_expression.h>
 #include <algorithm>
 #include <functional>
 #include <ostream>
@@ -204,6 +205,10 @@ using ColumnOidToIdMap = std::unordered_map<catalog::col_oid_t, col_id_t>;
  * Used by SqlTable to map between col_ids in BlockLayout and col_oids in Schema
  */
 using ColumnIdToOidMap = std::unordered_map<col_id_t, catalog::col_oid_t>;
+/*
+ * Used by SqlTable to map between col_ids in BlockLayout and default values in Schema
+ */
+using DefaultValueMap = std::unordered_map<col_id_t, common::ManagedPointer<parser::AbstractExpression>>;
 /**
  * Used by execution and storage layers to map between col_oids and offsets within a ProjectedRow
  */

--- a/src/include/storage/storage_defs.h
+++ b/src/include/storage/storage_defs.h
@@ -20,6 +20,9 @@
 #include "storage/write_ahead_log/log_io.h"
 #include "transaction/transaction_defs.h"
 
+namespace terrier::parser {
+class AbstractExpression;
+}
 namespace terrier::storage {
 
 // In type_util.h there are a total of 5 possible inlined attribute sizes:
@@ -204,6 +207,7 @@ using ColumnOidToIdMap = std::unordered_map<catalog::col_oid_t, col_id_t>;
  * Used by SqlTable to map between col_ids in BlockLayout and col_oids in Schema
  */
 using ColumnIdToOidMap = std::unordered_map<col_id_t, catalog::col_oid_t>;
+using DefaultValueMap = std::unordered_map<col_id_t, common::ManagedPointer<const parser::AbstractExpression>>;
 /**
  * Used by execution and storage layers to map between col_oids and offsets within a ProjectedRow
  */

--- a/src/include/storage/storage_defs.h
+++ b/src/include/storage/storage_defs.h
@@ -37,6 +37,7 @@ STRONG_TYPEDEF(layout_version_t, uint16_t);
 // This is not to be confused with a non-null version vector that has value nullptr (0).
 
 constexpr col_id_t VERSION_POINTER_COLUMN_ID = col_id_t(0);
+constexpr col_id_t IGNORE_COLUMN_ID = col_id_t(UINT16_MAX);
 constexpr uint8_t NUM_RESERVED_COLUMNS = 1;
 
 class DataTable;
@@ -198,7 +199,11 @@ using BlockStore = common::ObjectPool<RawBlock, BlockAllocator>;
 /**
  * Used by SqlTable to map between col_oids in Schema and col_ids in BlockLayout
  */
-using ColumnMap = std::unordered_map<catalog::col_oid_t, col_id_t>;
+using ColumnOidToIdMap = std::unordered_map<catalog::col_oid_t, col_id_t>;
+/**
+ * Used by SqlTable to map between col_ids in BlockLayout and col_oids in Schema
+ */
+using ColumnIdToOidMap = std::unordered_map<col_id_t, catalog::col_oid_t>;
 /**
  * Used by execution and storage layers to map between col_oids and offsets within a ProjectedRow
  */

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -40,26 +40,24 @@ bool DataTable::Select(const common::ManagedPointer<transaction::TransactionCont
   return SelectIntoBuffer(txn, slot, out_buffer);
 }
 
-// void DataTable::Scan(const common::ManagedPointer<transaction::TransactionContext> txn, SlotIterator *const
-// start_pos,
-//                      ProjectedColumns *const out_buffer) const {
-//   // TODO(Tianyu): So far this is not that much better than tuple-at-a-time access,
-//   // but can be improved if block is read-only, or if we implement version synopsis, to just use std::memcpy when
-//   it's
-//   // safe
-//   uint32_t filled = 0;
-//   while (filled < out_buffer->MaxTuples() && *start_pos != end()) {
-//     ProjectedColumns::RowView row = out_buffer->InterpretAsRow(filled);
-//     const TupleSlot slot = **start_pos;
-//     // Only fill the buffer with valid, visible tuples
-//     if (SelectIntoBuffer(txn, slot, &row)) {
-//       out_buffer->TupleSlots()[filled] = slot;
-//       filled++;
-//     }
-//     ++(*start_pos);
-//   }
-//   out_buffer->SetNumTuples(filled);
-// }
+void DataTable::Scan(const common::ManagedPointer<transaction::TransactionContext> txn, SlotIterator *const start_pos,
+                     ProjectedColumns *const out_buffer) const {
+  // TODO(Tianyu): So far this is not that much better than tuple-at-a-time access,
+  // but can be improved if block is read-only, or if we implement version synopsis, to just use std::memcpy when it's
+  // safe
+  uint32_t filled = 0;
+  while (filled < out_buffer->MaxTuples() && *start_pos != end()) {
+    ProjectedColumns::RowView row = out_buffer->InterpretAsRow(filled);
+    const TupleSlot slot = **start_pos;
+    // Only fill the buffer with valid, visible tuples
+    if (SelectIntoBuffer(txn, slot, &row)) {
+      out_buffer->TupleSlots()[filled] = slot;
+      filled++;
+    }
+    ++(*start_pos);
+  }
+  out_buffer->SetNumTuples(filled);
+}
 
 // TODO(Schema-Change): we will need to go to the next DataTable once we reached the end of current block by either
 // chasing

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -278,6 +278,7 @@ bool DataTable::SelectIntoBuffer(const common::ManagedPointer<transaction::Trans
     for (uint16_t i = 0; i < out_buffer->NumColumns(); i++) {
       TERRIER_ASSERT(out_buffer->ColumnIds()[i] != VERSION_POINTER_COLUMN_ID,
                      "Output buffer should not read the version pointer column.");
+      if (out_buffer->ColumnIds()[i] != IGNORE_COLUMN_ID) continue;
       StorageUtil::CopyAttrIntoProjection(accessor_, slot, out_buffer, i);
     }
 

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -59,7 +59,8 @@ void DataTable::Scan(const common::ManagedPointer<transaction::TransactionContex
   out_buffer->SetNumTuples(filled);
 }
 
-// TODO(Schema-Change): we will need to go to the next DataTable once we reached the end of current block by either chasing
+// TODO(Schema-Change): we will need to go to the next DataTable once we reached the end of current block by either
+// chasing
 //  the pointer to the next datatable, or consulting SqlTable to obtain such information
 DataTable::SlotIterator &DataTable::SlotIterator::operator++() {
   // TODO(Lin): We need to temporarily comment out this latch for the concurrent TPCH experiments. Should be replaced
@@ -261,9 +262,9 @@ bool DataTable::Delete(const common::ManagedPointer<transaction::TransactionCont
 template <class RowType>
 bool DataTable::SelectIntoBuffer(const common::ManagedPointer<transaction::TransactionContext> txn,
                                  const TupleSlot slot, RowType *const out_buffer) const {
-  TERRIER_ASSERT(out_buffer->NumColumns() <= accessor_.GetBlockLayout().NumColumns() - NUM_RESERVED_COLUMNS,
-                 "The output buffer never returns the version pointer columns, so it should have "
-                 "fewer attributes.");
+  //  TERRIER_ASSERT(out_buffer->NumColumns() <= accessor_.GetBlockLayout().NumColumns() - NUM_RESERVED_COLUMNS,
+  //                 "The output buffer never returns the version pointer columns, so it should have "
+  //                 "fewer attributes.");
   TERRIER_ASSERT(out_buffer->NumColumns() > 0, "The output buffer should return at least one attribute.");
   // This cannot be visible if it's already deallocated.
   if (!accessor_.Allocated(slot)) return false;
@@ -278,7 +279,8 @@ bool DataTable::SelectIntoBuffer(const common::ManagedPointer<transaction::Trans
     for (uint16_t i = 0; i < out_buffer->NumColumns(); i++) {
       TERRIER_ASSERT(out_buffer->ColumnIds()[i] != VERSION_POINTER_COLUMN_ID,
                      "Output buffer should not read the version pointer column.");
-      if (out_buffer->ColumnIds()[i] != IGNORE_COLUMN_ID) continue;
+      // TODO(Schem-Change): pre-set columns belonging to newer schema to null to facilitate future default value change
+      if (out_buffer->ColumnIds()[i] != IGNORE_COLUMN_ID) StorageUtil::CopyWithNullCheck(nullptr, out_buffer, 0, i);
       StorageUtil::CopyAttrIntoProjection(accessor_, slot, out_buffer, i);
     }
 

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -40,24 +40,26 @@ bool DataTable::Select(const common::ManagedPointer<transaction::TransactionCont
   return SelectIntoBuffer(txn, slot, out_buffer);
 }
 
-void DataTable::Scan(const common::ManagedPointer<transaction::TransactionContext> txn, SlotIterator *const start_pos,
-                     ProjectedColumns *const out_buffer) const {
-  // TODO(Tianyu): So far this is not that much better than tuple-at-a-time access,
-  // but can be improved if block is read-only, or if we implement version synopsis, to just use std::memcpy when it's
-  // safe
-  uint32_t filled = 0;
-  while (filled < out_buffer->MaxTuples() && *start_pos != end()) {
-    ProjectedColumns::RowView row = out_buffer->InterpretAsRow(filled);
-    const TupleSlot slot = **start_pos;
-    // Only fill the buffer with valid, visible tuples
-    if (SelectIntoBuffer(txn, slot, &row)) {
-      out_buffer->TupleSlots()[filled] = slot;
-      filled++;
-    }
-    ++(*start_pos);
-  }
-  out_buffer->SetNumTuples(filled);
-}
+// void DataTable::Scan(const common::ManagedPointer<transaction::TransactionContext> txn, SlotIterator *const
+// start_pos,
+//                      ProjectedColumns *const out_buffer) const {
+//   // TODO(Tianyu): So far this is not that much better than tuple-at-a-time access,
+//   // but can be improved if block is read-only, or if we implement version synopsis, to just use std::memcpy when
+//   it's
+//   // safe
+//   uint32_t filled = 0;
+//   while (filled < out_buffer->MaxTuples() && *start_pos != end()) {
+//     ProjectedColumns::RowView row = out_buffer->InterpretAsRow(filled);
+//     const TupleSlot slot = **start_pos;
+//     // Only fill the buffer with valid, visible tuples
+//     if (SelectIntoBuffer(txn, slot, &row)) {
+//       out_buffer->TupleSlots()[filled] = slot;
+//       filled++;
+//     }
+//     ++(*start_pos);
+//   }
+//   out_buffer->SetNumTuples(filled);
+// }
 
 // TODO(Schema-Change): we will need to go to the next DataTable once we reached the end of current block by either
 // chasing

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -59,7 +59,8 @@ void DataTable::Scan(const common::ManagedPointer<transaction::TransactionContex
   out_buffer->SetNumTuples(filled);
 }
 
-// TODO(Schema-Change): we will need to go to the next DataTable once we reached the end of current block by either chasing
+// TODO(Schema-Change): we will need to go to the next DataTable once we reached the end of current block by either
+// chasing
 //  the pointer to the next datatable, or consulting SqlTable to obtain such information
 DataTable::SlotIterator &DataTable::SlotIterator::operator++() {
   // TODO(Lin): We need to temporarily comment out this latch for the concurrent TPCH experiments. Should be replaced

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -59,6 +59,8 @@ void DataTable::Scan(const common::ManagedPointer<transaction::TransactionContex
   out_buffer->SetNumTuples(filled);
 }
 
+// TODO(Schema-Change): we will need to go to the next DataTable once we reached the end of current block by either chasing
+//  the pointer to the next datatable, or consulting SqlTable to obtain such information
 DataTable::SlotIterator &DataTable::SlotIterator::operator++() {
   // TODO(Lin): We need to temporarily comment out this latch for the concurrent TPCH experiments. Should be replaced
   //  with a real solution

--- a/src/storage/recovery/recovery_manager.cpp
+++ b/src/storage/recovery/recovery_manager.cpp
@@ -163,7 +163,7 @@ void RecoveryManager::ReplayRedoRecord(transaction::TransactionContext *txn, Log
     // Stage the write. This way the recovery operation is logged if logging is enabled
     auto staged_record = txn->StageRecoveryWrite(record);
     TERRIER_ASSERT(staged_record->GetTupleSlot() == new_tuple_slot, "Staged record must have the mapped tuple slot");
-    bool result UNUSED_ATTRIBUTE = sql_table_ptr->Update(common::ManagedPointer(txn), staged_record);
+    bool result UNUSED_ATTRIBUTE = sql_table_ptr->Update(common::ManagedPointer(txn), staged_record).first;
     TERRIER_ASSERT(result, "Buffered changes should always succeed during commit");
   }
 }

--- a/src/storage/sql_table.cpp
+++ b/src/storage/sql_table.cpp
@@ -5,7 +5,6 @@
 #include <vector>
 
 #include "common/macros.h"
-#include "parser/expression/abstract_expression.h"
 #include "storage/storage_util.h"
 
 namespace terrier::storage {

--- a/src/storage/sql_table.cpp
+++ b/src/storage/sql_table.cpp
@@ -29,23 +29,29 @@ SqlTable::SqlTable(const common::ManagedPointer<BlockStore> store, const catalog
 
   auto offsets = storage::StorageUtil::ComputeBaseAttributeOffsets(attr_sizes, NUM_RESERVED_COLUMNS);
 
-  ColumnMap col_oid_to_id;
+  ColumnOidToIdMap col_oid_to_id;
+  ColumnIdToOidMap col_id_to_oid;
   // Build the map from Schema columns to underlying columns
   for (const auto &column : schema.GetColumns()) {
     switch (column.AttrSize()) {
       case VARLEN_COLUMN:
+        col_id_to_oid[col_id_t(offsets[0])] = column.Oid();
         col_oid_to_id[column.Oid()] = col_id_t(offsets[0]++);
         break;
       case 8:
+        col_id_to_oid[col_id_t(offsets[1])] = column.Oid();
         col_oid_to_id[column.Oid()] = col_id_t(offsets[1]++);
         break;
       case 4:
+        col_id_to_oid[col_id_t(offsets[2])] = column.Oid();
         col_oid_to_id[column.Oid()] = col_id_t(offsets[2]++);
         break;
       case 2:
+        col_id_to_oid[col_id_t(offsets[3])] = column.Oid();
         col_oid_to_id[column.Oid()] = col_id_t(offsets[3]++);
         break;
       case 1:
+        col_id_to_oid[col_id_t(offsets[4])] = column.Oid();
         col_oid_to_id[column.Oid()] = col_id_t(offsets[4]++);
         break;
       default:
@@ -54,7 +60,61 @@ SqlTable::SqlTable(const common::ManagedPointer<BlockStore> store, const catalog
   }
 
   auto layout = storage::BlockLayout(attr_sizes);
-  table_ = {new DataTable(block_store_, layout, layout_version_t(0)), layout, col_oid_to_id};
+  tables_ = {
+      {layout_version_t(0),
+       {new DataTable(block_store_, layout, layout_version_t(0)), layout, col_oid_to_id, col_id_to_oid}}
+  };
+}
+
+
+bool SqlTable::Select(const common::ManagedPointer <transaction::TransactionContext> txn, layout_version_t layout_version,
+                      const TupleSlot slot, ProjectedRow *const out_buffer) const {
+
+  // get the version of current tuple slot
+  const auto tuple_version = slot.GetBlock()->data_table_->layout_version_;
+
+  TERRIER_ASSERT(tuple_version <= layout_version, "The iterator should not go to data tables with more recent version than the current transaction.");
+
+  if (tuple_version == layout_version) {
+    // when current version is same as the intended layout version, get the tuple without transformation
+    return tables_.at(tuple_version).data_table_->Select(txn, slot, out_buffer);
+  } else {
+    // the tuple exists in an older version.
+    // TODO(schema-change): handle versions from add and/or drop column only
+    col_id_t ori_header[out_buffer->NumColumns()];
+    std::vector<catalog::col_oid_t> missing_cols;
+
+    auto desired_v = tables_.at(layout_version);
+    auto tuple_v = tables_.at(tuple_version);
+    AlignHeaderToVersion(out_buffer, tuple_v, desired_v, &ori_header[0], &missing_cols);
+    auto result = tables_.at(tuple_version).data_table_->Select(txn, slot, out_buffer);
+    // TODO(Schema-Change): fill in default values if there are missing columns
+    if (!missing_cols.empty()) {
+
+    }
+    // TODO(Schema-Change): Do we need to copy back the original header
+    return result;
+  }
+}
+
+bool SqlTable::AlignHeaderToVersion(ProjectedRow *const out_buffer, const DataTableVersion &tuple_version,
+                                    const DataTableVersion &desired_version, col_id_t *cached_ori_header,
+                                    std::vector<catalog::col_oid_t>* const missing_cols) const {
+  // reserve the original header, aka intended column ids'
+  std::memcpy(cached_ori_header, out_buffer->ColumnIds(), sizeof(col_id_t) * out_buffer->NumColumns());
+
+  // for each column id in the intended version of datatable, change it to match the current schema version
+  for (uint16_t i = 0; i < out_buffer->NumColumns(); i++) {
+    TERRIER_ASSERT(out_buffer->ColumnIds()[i] != VERSION_POINTER_COLUMN_ID,
+                   "Output buffer should not read the version pointer column.");
+    catalog::col_oid_t col_oid = desired_version.column_id_to_oid_map_.at(out_buffer->ColumnIds()[i]);
+    if (tuple_version.column_oid_to_id_map_.count(col_oid) > 0) {
+      out_buffer->ColumnIds()[i] = tuple_version.column_oid_to_id_map_.at(col_oid);
+    } else {
+      out_buffer->ColumnIds()[i] = IGNORE_COLUMN_ID;
+      missing_cols->emplace_back(col_oid);
+    }
+  }
 }
 
 std::vector<col_id_t> SqlTable::ColIdsForOids(const std::vector<catalog::col_oid_t> &col_oids) const {

--- a/src/storage/sql_table.cpp
+++ b/src/storage/sql_table.cpp
@@ -62,7 +62,7 @@ SqlTable::SqlTable(const common::ManagedPointer<BlockStore> store, const catalog
   auto layout = storage::BlockLayout(attr_sizes);
   tables_ = {
       {layout_version_t(0),
-       {new DataTable(block_store_, layout, layout_version_t(0)), layout, col_oid_to_id, col_id_to_oid}}
+       {new DataTable(block_store_, layout, layout_version_t(0)), layout, col_oid_to_id, col_id_to_oid, common::ManagedPointer<const catalog::Schema>(&schema)}}
   };
 }
 
@@ -91,7 +91,7 @@ bool SqlTable::Select(const common::ManagedPointer <transaction::TransactionCont
     // TODO(Schema-Change): fill in default values if there are missing columns.
     //   The missing columns can be in any datatable version between the tuple version and layout version
     if (!missing_cols.empty()) {
-
+      // fill in default values
     }
     // TODO(Schema-Change): Do we need to copy back the original header
     std::memcpy(out_buffer->ColumnIds(), ori_header, sizeof(col_id_t) * out_buffer->NumColumns());

--- a/src/storage/sql_table.cpp
+++ b/src/storage/sql_table.cpp
@@ -88,16 +88,66 @@ bool SqlTable::Select(const common::ManagedPointer <transaction::TransactionCont
     auto tuple_v = tables_.at(tuple_version);
     AlignHeaderToVersion(out_buffer, tuple_v, desired_v, &ori_header[0], &missing_cols);
     auto result = tables_.at(tuple_version).data_table_->Select(txn, slot, out_buffer);
-    // TODO(Schema-Change): fill in default values if there are missing columns
+    // TODO(Schema-Change): fill in default values if there are missing columns.
+    //   The missing columns can be in any datatable version between the tuple version and layout version
     if (!missing_cols.empty()) {
 
     }
     // TODO(Schema-Change): Do we need to copy back the original header
+    std::memcpy(out_buffer->ColumnIds(), ori_header, sizeof(col_id_t) * out_buffer->NumColumns());
     return result;
   }
 }
 
-bool SqlTable::AlignHeaderToVersion(ProjectedRow *const out_buffer, const DataTableVersion &tuple_version,
+bool SqlTable::Update(const common::ManagedPointer <transaction::TransactionContext> txn,
+            layout_version_t layout_version, RedoRecord *const redo) const {
+  TERRIER_ASSERT(redo->GetTupleSlot() != TupleSlot(nullptr, 0), "TupleSlot was never set in this RedoRecord.");
+  TERRIER_ASSERT(redo == reinterpret_cast<LogRecord *>(txn->redo_buffer_.LastRecord())
+      ->LogRecord::GetUnderlyingRecordBodyAs<RedoRecord>(),
+                 "This RedoRecord is not the most recent entry in the txn's RedoBuffer. Was StageWrite called "
+                 "immediately before?");
+  // TODO(Schema-Change): Similarly, need to go through all relavent datatables.
+  //  Also need to take care of tuple migration if the update touches the new columns added
+  //  The migration should be a delete (MVCC style) in old datatable followed by an insert in new datatable.
+
+  // get the version of current tuple slot
+  const auto curr_tuple = redo->GetTupleSlot();
+  const auto tuple_version = curr_tuple.GetBlock()->data_table_->layout_version_;
+
+  TERRIER_ASSERT(tuple_version <= layout_version, "The iterator should not go to data tables with more recent version than the current transaction.");
+
+  bool result;
+  if (tuple_version == layout_version) {
+    result = tables_.at(layout_version).data_table_->Update(txn, curr_tuple, *(redo->Delta()));
+  } else {
+    // tuple in an older version, check if all modified columns are in the datatable version where the tuple is in
+    auto desired_v = tables_.at(layout_version);
+    auto tuple_v = tables_.at(tuple_version);
+
+    col_id_t ori_header[redo->Delta()->NumColumns()];
+    std::vector<catalog::col_oid_t> missing_cols;
+    AlignHeaderToVersion(redo->Delta(), tuple_v, desired_v, &ori_header[0], &missing_cols);
+
+    if (missing_cols.empty()) {
+      result = tuple_v.data_table_->Update(txn, redo->GetTupleSlot(), *(redo->Delta()));
+      std::memcpy(redo->Delta()->ColumnIds(), ori_header, sizeof(col_id_t) * redo->Delta()->NumColumns());
+    } else {
+      // touching columns that are in the desired schema, but not the actual schema
+      // do an delete followed by an insert
+    }
+
+
+
+  }
+  if (!result) {
+    // For MVCC correctness, this txn must now abort for the GC to clean up the version chain in the DataTable
+    // correctly.
+    txn->SetMustAbort();
+  }
+  return result;
+}
+
+void SqlTable::AlignHeaderToVersion(ProjectedRow *const out_buffer, const DataTableVersion &tuple_version,
                                     const DataTableVersion &desired_version, col_id_t *cached_ori_header,
                                     std::vector<catalog::col_oid_t>* const missing_cols) const {
   // reserve the original header, aka intended column ids'
@@ -117,29 +167,38 @@ bool SqlTable::AlignHeaderToVersion(ProjectedRow *const out_buffer, const DataTa
   }
 }
 
-std::vector<col_id_t> SqlTable::ColIdsForOids(const std::vector<catalog::col_oid_t> &col_oids) const {
+std::vector<col_id_t> SqlTable::ColIdsForOids(const std::vector<catalog::col_oid_t> &col_oids, layout_version_t layout_version) const {
   TERRIER_ASSERT(!col_oids.empty(), "Should be used to access at least one column.");
   std::vector<col_id_t> col_ids;
 
   // Build the input to the initializer constructor
   for (const catalog::col_oid_t col_oid : col_oids) {
-    TERRIER_ASSERT(table_.column_map_.count(col_oid) > 0, "Provided col_oid does not exist in the table.");
-    const col_id_t col_id = table_.column_map_.at(col_oid);
+    TERRIER_ASSERT(tables_.at(layout_version).column_oid_to_id_map_.count(col_oid) > 0, "Provided col_oid does not exist in the table.");
+    const col_id_t col_id = tables_.at(layout_version).column_oid_to_id_map_.at(col_oid);
     col_ids.push_back(col_id);
   }
 
   return col_ids;
 }
 
-ProjectionMap SqlTable::ProjectionMapForOids(const std::vector<catalog::col_oid_t> &col_oids) {
+ProjectionMap SqlTable::ProjectionMapForOids(const std::vector<catalog::col_oid_t> &col_oids, layout_version_t layout_version) {
   // Resolve OIDs to storage IDs
-  auto col_ids = ColIdsForOids(col_oids);
+//  auto col_ids = ColIdsForOids(col_oids);
 
   // Use std::map to effectively sort OIDs by their corresponding ID
   std::map<col_id_t, catalog::col_oid_t> inverse_map;
-  for (uint16_t i = 0; i < col_oids.size(); i++) inverse_map[col_ids[i]] = col_oids[i];
+  TERRIER_ASSERT(!col_oids.empty(), "Should be used to access at least one column.");
+  // Build the input to the initializer constructor
+  for (const catalog::col_oid_t col_oid : col_oids) {
+    TERRIER_ASSERT(tables_.at(layout_version).column_oid_to_id_map_.count(col_oid) > 0, "Provided col_oid does not exist in the table.");
+    const col_id_t col_id = tables_.at(layout_version).column_oid_to_id_map_.at(col_oid);
+    inverse_map[col_id] = col_oid;
+  }
+
+  // for (uint16_t i = 0; i < col_oids.size(); i++) inverse_map[col_ids[i]] = col_oids[i];
 
   // Populate the projection map using the in-order iterator on std::map
+  // TODO(Schema-Change): Does this actually retain ordering?
   ProjectionMap projection_map;
   uint16_t i = 0;
   for (auto &iter : inverse_map) projection_map[iter.second] = i++;
@@ -147,10 +206,11 @@ ProjectionMap SqlTable::ProjectionMapForOids(const std::vector<catalog::col_oid_
   return projection_map;
 }
 
-catalog::col_oid_t SqlTable::OidForColId(const col_id_t col_id) const {
-  const auto oid_to_id = std::find_if(table_.column_map_.cbegin(), table_.column_map_.cend(),
-                                      [&](const auto &oid_to_id) -> bool { return oid_to_id.second == col_id; });
-  return oid_to_id->first;
+catalog::col_oid_t SqlTable::OidForColId(const col_id_t col_id, layout_version_t layout_version) const {
+//  const auto oid_to_id = std::find_if(table_.column_map_.cbegin(), table_.column_map_.cend(),
+//                                      [&](const auto &oid_to_id) -> bool { return oid_to_id.second == col_id; });
+//  return oid_to_id->first;
+  return tables_.at(layout_version).column_id_to_oid_map_.at(col_id);
 }
 
 }  // namespace terrier::storage

--- a/src/storage/sql_table.cpp
+++ b/src/storage/sql_table.cpp
@@ -176,8 +176,8 @@ SqlTable::DataTableVersion SqlTable::CreateTable(
 
   auto layout = storage::BlockLayout(attr_sizes);
   tables_ = {{layout_version_t(0),
-              {new DataTable(block_store_, layout, layout_version_t(0)), layout, col_oid_to_id, col_id_to_oid,
-               schema, default_value_map}}};
+              {new DataTable(block_store_, layout, layout_version_t(0)), layout, col_oid_to_id, col_id_to_oid, schema,
+               default_value_map}}};
 }
 
 std::vector<col_id_t> SqlTable::ColIdsForOids(const std::vector<catalog::col_oid_t> &col_oids,

--- a/src/storage/sql_table.cpp
+++ b/src/storage/sql_table.cpp
@@ -31,6 +31,7 @@ SqlTable::SqlTable(const common::ManagedPointer<BlockStore> store, const catalog
 
   ColumnOidToIdMap col_oid_to_id;
   ColumnIdToOidMap col_id_to_oid;
+  DefaultValueMap default_value_map;
   // Build the map from Schema columns to underlying columns
   for (const auto &column : schema.GetColumns()) {
     switch (column.AttrSize()) {
@@ -57,23 +58,23 @@ SqlTable::SqlTable(const common::ManagedPointer<BlockStore> store, const catalog
       default:
         throw std::runtime_error("unexpected switch case value");
     }
+    auto default_value = column.StoredExpression();
+    if (default_value != nullptr) default_value_map[col_id_t(offsets[0])] = default_value;
   }
 
   auto layout = storage::BlockLayout(attr_sizes);
-  tables_ = {
-      {layout_version_t(0),
-       {new DataTable(block_store_, layout, layout_version_t(0)), layout, col_oid_to_id, col_id_to_oid, common::ManagedPointer<const catalog::Schema>(&schema)}}
-  };
+  tables_ = {{layout_version_t(0),
+              {new DataTable(block_store_, layout, layout_version_t(0)), layout, col_oid_to_id, col_id_to_oid,
+               common::ManagedPointer<const catalog::Schema>(&schema), default_value_map}}};
 }
 
-
-bool SqlTable::Select(const common::ManagedPointer <transaction::TransactionContext> txn, layout_version_t layout_version,
-                      const TupleSlot slot, ProjectedRow *const out_buffer) const {
-
+bool SqlTable::Select(const common::ManagedPointer<transaction::TransactionContext> txn,
+                      layout_version_t layout_version, const TupleSlot slot, ProjectedRow *const out_buffer) const {
   // get the version of current tuple slot
   const auto tuple_version = slot.GetBlock()->data_table_->layout_version_;
 
-  TERRIER_ASSERT(tuple_version <= layout_version, "The iterator should not go to data tables with more recent version than the current transaction.");
+  TERRIER_ASSERT(tuple_version <= layout_version,
+                 "The iterator should not go to data tables with more recent version than the current transaction.");
 
   if (tuple_version == layout_version) {
     // when current version is same as the intended layout version, get the tuple without transformation
@@ -82,28 +83,26 @@ bool SqlTable::Select(const common::ManagedPointer <transaction::TransactionCont
     // the tuple exists in an older version.
     // TODO(schema-change): handle versions from add and/or drop column only
     col_id_t ori_header[out_buffer->NumColumns()];
-    std::vector<catalog::col_oid_t> missing_cols;
 
     auto desired_v = tables_.at(layout_version);
     auto tuple_v = tables_.at(tuple_version);
-    AlignHeaderToVersion(out_buffer, tuple_v, desired_v, &ori_header[0], &missing_cols);
+    AlignHeaderToVersion(out_buffer, tuple_v, desired_v, &ori_header[0]);
     auto result = tables_.at(tuple_version).data_table_->Select(txn, slot, out_buffer);
-    // TODO(Schema-Change): fill in default values if there are missing columns.
-    //   The missing columns can be in any datatable version between the tuple version and layout version
-    if (!missing_cols.empty()) {
-      // fill in default values
-    }
-    // TODO(Schema-Change): Do we need to copy back the original header
+
+    // copy back the original header
     std::memcpy(out_buffer->ColumnIds(), ori_header, sizeof(col_id_t) * out_buffer->NumColumns());
+
+    // fill in missing columns and default values
+    FillMissingColumns(out_buffer, desired_v);
     return result;
   }
 }
 
-bool SqlTable::Update(const common::ManagedPointer <transaction::TransactionContext> txn,
-            layout_version_t layout_version, RedoRecord *const redo) const {
+bool SqlTable::Update(const common::ManagedPointer<transaction::TransactionContext> txn,
+                      layout_version_t layout_version, RedoRecord *const redo) const {
   TERRIER_ASSERT(redo->GetTupleSlot() != TupleSlot(nullptr, 0), "TupleSlot was never set in this RedoRecord.");
   TERRIER_ASSERT(redo == reinterpret_cast<LogRecord *>(txn->redo_buffer_.LastRecord())
-      ->LogRecord::GetUnderlyingRecordBodyAs<RedoRecord>(),
+                             ->LogRecord::GetUnderlyingRecordBodyAs<RedoRecord>(),
                  "This RedoRecord is not the most recent entry in the txn's RedoBuffer. Was StageWrite called "
                  "immediately before?");
   // TODO(Schema-Change): Similarly, need to go through all relavent datatables.
@@ -114,7 +113,8 @@ bool SqlTable::Update(const common::ManagedPointer <transaction::TransactionCont
   const auto curr_tuple = redo->GetTupleSlot();
   const auto tuple_version = curr_tuple.GetBlock()->data_table_->layout_version_;
 
-  TERRIER_ASSERT(tuple_version <= layout_version, "The iterator should not go to data tables with more recent version than the current transaction.");
+  TERRIER_ASSERT(tuple_version <= layout_version,
+                 "The iterator should not go to data tables with more recent version than the current transaction.");
 
   bool result;
   if (tuple_version == layout_version) {
@@ -126,7 +126,7 @@ bool SqlTable::Update(const common::ManagedPointer <transaction::TransactionCont
 
     col_id_t ori_header[redo->Delta()->NumColumns()];
     std::vector<catalog::col_oid_t> missing_cols;
-    AlignHeaderToVersion(redo->Delta(), tuple_v, desired_v, &ori_header[0], &missing_cols);
+    AlignHeaderToVersion(redo->Delta(), tuple_v, desired_v, &ori_header[0]);
 
     if (missing_cols.empty()) {
       result = tuple_v.data_table_->Update(txn, redo->GetTupleSlot(), *(redo->Delta()));
@@ -135,9 +135,6 @@ bool SqlTable::Update(const common::ManagedPointer <transaction::TransactionCont
       // touching columns that are in the desired schema, but not the actual schema
       // do an delete followed by an insert
     }
-
-
-
   }
   if (!result) {
     // For MVCC correctness, this txn must now abort for the GC to clean up the version chain in the DataTable
@@ -147,9 +144,19 @@ bool SqlTable::Update(const common::ManagedPointer <transaction::TransactionCont
   return result;
 }
 
+void SqlTable::FillMissingColumns(ProjectedRow *const out_buffer, const DataTableVersion &desired_version) const {
+  const auto col_ids = out_buffer->ColumnIds();
+  for (uint16_t i = 0; i < out_buffer->NumColumns(); i++) {
+    const auto default_val = desired_version.default_value_map_[col_ids[i]];
+    if (out_buffer->AccessWithNullCheck(i) == nullptr && default_val != nullptr) {
+      auto col_oid = desired_version.column_id_to_oid_map_.at(col_ids[i]);
+      StorageUtil::CopyWithNullCheck(default_val, out_buffer, desired_version.schema_->GetColumn(col_oid).AttrSize(),
+                                     i);
+    }
+  }
+}
 void SqlTable::AlignHeaderToVersion(ProjectedRow *const out_buffer, const DataTableVersion &tuple_version,
-                                    const DataTableVersion &desired_version, col_id_t *cached_ori_header,
-                                    std::vector<catalog::col_oid_t>* const missing_cols) const {
+                                    const DataTableVersion &desired_version, col_id_t *cached_ori_header) const {
   // reserve the original header, aka intended column ids'
   std::memcpy(cached_ori_header, out_buffer->ColumnIds(), sizeof(col_id_t) * out_buffer->NumColumns());
 
@@ -162,18 +169,19 @@ void SqlTable::AlignHeaderToVersion(ProjectedRow *const out_buffer, const DataTa
       out_buffer->ColumnIds()[i] = tuple_version.column_oid_to_id_map_.at(col_oid);
     } else {
       out_buffer->ColumnIds()[i] = IGNORE_COLUMN_ID;
-      missing_cols->emplace_back(col_oid);
     }
   }
 }
 
-std::vector<col_id_t> SqlTable::ColIdsForOids(const std::vector<catalog::col_oid_t> &col_oids, layout_version_t layout_version) const {
+std::vector<col_id_t> SqlTable::ColIdsForOids(const std::vector<catalog::col_oid_t> &col_oids,
+                                              layout_version_t layout_version) const {
   TERRIER_ASSERT(!col_oids.empty(), "Should be used to access at least one column.");
   std::vector<col_id_t> col_ids;
 
   // Build the input to the initializer constructor
   for (const catalog::col_oid_t col_oid : col_oids) {
-    TERRIER_ASSERT(tables_.at(layout_version).column_oid_to_id_map_.count(col_oid) > 0, "Provided col_oid does not exist in the table.");
+    TERRIER_ASSERT(tables_.at(layout_version).column_oid_to_id_map_.count(col_oid) > 0,
+                   "Provided col_oid does not exist in the table.");
     const col_id_t col_id = tables_.at(layout_version).column_oid_to_id_map_.at(col_oid);
     col_ids.push_back(col_id);
   }
@@ -181,16 +189,18 @@ std::vector<col_id_t> SqlTable::ColIdsForOids(const std::vector<catalog::col_oid
   return col_ids;
 }
 
-ProjectionMap SqlTable::ProjectionMapForOids(const std::vector<catalog::col_oid_t> &col_oids, layout_version_t layout_version) {
+ProjectionMap SqlTable::ProjectionMapForOids(const std::vector<catalog::col_oid_t> &col_oids,
+                                             layout_version_t layout_version) {
   // Resolve OIDs to storage IDs
-//  auto col_ids = ColIdsForOids(col_oids);
+  //  auto col_ids = ColIdsForOids(col_oids);
 
   // Use std::map to effectively sort OIDs by their corresponding ID
   std::map<col_id_t, catalog::col_oid_t> inverse_map;
   TERRIER_ASSERT(!col_oids.empty(), "Should be used to access at least one column.");
   // Build the input to the initializer constructor
   for (const catalog::col_oid_t col_oid : col_oids) {
-    TERRIER_ASSERT(tables_.at(layout_version).column_oid_to_id_map_.count(col_oid) > 0, "Provided col_oid does not exist in the table.");
+    TERRIER_ASSERT(tables_.at(layout_version).column_oid_to_id_map_.count(col_oid) > 0,
+                   "Provided col_oid does not exist in the table.");
     const col_id_t col_id = tables_.at(layout_version).column_oid_to_id_map_.at(col_oid);
     inverse_map[col_id] = col_oid;
   }
@@ -207,9 +217,9 @@ ProjectionMap SqlTable::ProjectionMapForOids(const std::vector<catalog::col_oid_
 }
 
 catalog::col_oid_t SqlTable::OidForColId(const col_id_t col_id, layout_version_t layout_version) const {
-//  const auto oid_to_id = std::find_if(table_.column_map_.cbegin(), table_.column_map_.cend(),
-//                                      [&](const auto &oid_to_id) -> bool { return oid_to_id.second == col_id; });
-//  return oid_to_id->first;
+  //  const auto oid_to_id = std::find_if(table_.column_map_.cbegin(), table_.column_map_.cend(),
+  //                                      [&](const auto &oid_to_id) -> bool { return oid_to_id.second == col_id; });
+  //  return oid_to_id->first;
   return tables_.at(layout_version).column_id_to_oid_map_.at(col_id);
 }
 

--- a/test/include/test_util/storage_test_util.h
+++ b/test/include/test_util/storage_test_util.h
@@ -268,6 +268,60 @@ class StorageTestUtil {
     return memcmp(one.Content(), other.Content(), one.Size()) == 0;
   }
 
+
+  template <class RowType1, class RowType2>
+  static bool ProjectionListEqualShallowMatchSchema(const storage::BlockLayout &layout1, const RowType1 *const one,
+                                                    const storage::ProjectionMap &oid_map1,
+                                                    const storage::BlockLayout &layout2, const RowType2 *const other,
+                                                    const storage::ProjectionMap &oid_map2,
+                                                    const std::unordered_set<catalog::col_oid_t> &add_cols,
+                                                    const std::unordered_set<catalog::col_oid_t> &drop_cols) {
+    EXPECT_EQ(one->NumColumns(), other->NumColumns());
+    if (one->NumColumns() != other->NumColumns()) return false;
+
+    for (auto itr = oid_map1.begin(); itr != oid_map1.end(); itr++) {
+      auto oid1 = itr->first;
+      auto idx1 = itr->second;
+      if (drop_cols.find(oid1) != drop_cols.end()) {
+        auto idx2 = oid_map2.at(oid1);
+        storage::col_id_t one_id = one->ColumnIds()[idx1];
+        storage::col_id_t other_id = other->ColumnIds()[idx2];
+        EXPECT_EQ(one_id, other_id);
+        if (one_id != other_id) return false;
+
+        // Check that the two have the same content bit-wise
+        uint8_t attr_size = layout1.AttrSize(one_id);
+        const byte *one_content = one->AccessWithNullCheck(idx1);
+        const byte *other_content = other->AccessWithNullCheck(idx2);
+        // Either both are null or neither is null.
+        if (one_content == nullptr || other_content == nullptr) {
+          EXPECT_EQ(one_content, other_content);
+          if (one_content == other_content) continue;
+          return false;
+        }
+        // Otherwise, they should be bit-wise identical.
+        if (memcmp(one_content, other_content, attr_size) != 0) return false;
+      } else { // Column is dropped
+        // a dropped column should not exists in the map
+        EXPECT_EQ(oid_map2.find(oid1), oid_map2.end());
+        if(oid_map2.find(oid1) != oid_map2.end()) return false;
+      }
+    }
+
+    // Check for added columns
+    // TODO(Schema-change): how to check for the default value?
+    for(auto &added: add_cols) {
+      EXPECT_EQ(oid_map1.find(added), oid_map1.end());
+      if(oid_map1.find(added) != oid_map1.end()) return false;
+    }
+
+    return true;
+  }
+
+  static void SetOid(catalog::Schema::Column &col, catalog::col_oid_t oid) {
+    col.SetOid(oid);
+  }
+
   template <class RowType1, class RowType2>
   static bool ProjectionListEqualDeep(const storage::BlockLayout &layout, const RowType1 *const one,
                                       const RowType2 *const other) {
@@ -302,6 +356,7 @@ class StorageTestUtil {
     }
     return true;
   }
+
 
   template <class RowType1, class RowType2>
   static bool ProjectionListEqualShallow(const storage::BlockLayout &layout, const RowType1 *const one,

--- a/test/storage/log_test.cpp
+++ b/test/storage/log_test.cpp
@@ -332,7 +332,7 @@ TEST_F(WriteAheadLoggingTests, AbortRecordTest) {
   auto update_tuple = update_redo->Delta();
   *reinterpret_cast<int32_t *>(update_tuple->AccessForceNotNull(0)) = 0;
   update_redo->SetTupleSlot(first_tuple_slot);
-  EXPECT_FALSE(sql_table->Update(common::ManagedPointer(second_txn).first, update_redo));
+  EXPECT_FALSE(sql_table->Update(common::ManagedPointer(second_txn), update_redo).first);
 
   // Commit first txn and abort the second
   txn_manager_->Commit(first_txn, transaction::TransactionUtil::EmptyCallback, nullptr);
@@ -392,7 +392,7 @@ TEST_F(WriteAheadLoggingTests, NoAbortRecordTest) {
   auto update_tuple = update_redo->Delta();
   *reinterpret_cast<int32_t *>(update_tuple->AccessForceNotNull(0)) = 0;
   update_redo->SetTupleSlot(first_tuple_slot);
-  EXPECT_FALSE(sql_table->Update(common::ManagedPointer(second_txn).first, update_redo));
+  EXPECT_FALSE(sql_table->Update(common::ManagedPointer(second_txn), update_redo).first);
   EXPECT_FALSE(GetRedoBuffer(second_txn).HasFlushed());
 
   // Commit first txn and abort the second

--- a/test/storage/log_test.cpp
+++ b/test/storage/log_test.cpp
@@ -332,7 +332,7 @@ TEST_F(WriteAheadLoggingTests, AbortRecordTest) {
   auto update_tuple = update_redo->Delta();
   *reinterpret_cast<int32_t *>(update_tuple->AccessForceNotNull(0)) = 0;
   update_redo->SetTupleSlot(first_tuple_slot);
-  EXPECT_FALSE(sql_table->Update(common::ManagedPointer(second_txn), update_redo));
+  EXPECT_FALSE(sql_table->Update(common::ManagedPointer(second_txn).first, update_redo));
 
   // Commit first txn and abort the second
   txn_manager_->Commit(first_txn, transaction::TransactionUtil::EmptyCallback, nullptr);
@@ -392,7 +392,7 @@ TEST_F(WriteAheadLoggingTests, NoAbortRecordTest) {
   auto update_tuple = update_redo->Delta();
   *reinterpret_cast<int32_t *>(update_tuple->AccessForceNotNull(0)) = 0;
   update_redo->SetTupleSlot(first_tuple_slot);
-  EXPECT_FALSE(sql_table->Update(common::ManagedPointer(second_txn), update_redo));
+  EXPECT_FALSE(sql_table->Update(common::ManagedPointer(second_txn).first, update_redo));
   EXPECT_FALSE(GetRedoBuffer(second_txn).HasFlushed());
 
   // Commit first txn and abort the second

--- a/test/storage/recovery_test.cpp
+++ b/test/storage/recovery_test.cpp
@@ -155,7 +155,8 @@ class RecoveryTests : public TerrierTest {
   storage::RedoBuffer &GetRedoBuffer(transaction::TransactionContext *txn) { return txn->redo_buffer_; }
 
   storage::BlockLayout &GetBlockLayout(common::ManagedPointer<storage::SqlTable> table) const {
-    return table->table_.layout_;
+    // TODO(Schema-Change): get layout version here
+    return table->tables_.at(storage::layout_version_t(0)).layout_;
   }
 
   // Simulates the system shutting down and restarting
@@ -219,8 +220,9 @@ class RecoveryTests : public TerrierTest {
         auto recovered_sql_table = db_catalog->GetTable(common::ManagedPointer(recovery_txn), table_oid);
         EXPECT_TRUE(recovered_sql_table != nullptr);
 
+        // TODO(Schema-Change):: take care of current default 0 layout version
         EXPECT_TRUE(StorageTestUtil::SqlTableEqualDeep(
-            original_sql_table->table_.layout_, original_sql_table, recovered_sql_table,
+            original_sql_table->tables_.at(storage::layout_version_t(0)).layout_, original_sql_table, recovered_sql_table,
             tested->GetTupleSlotsForTable(database_oid, table_oid), recovery_manager.tuple_slot_map_,
             txn_manager_.Get(), recovery_txn_manager_.Get()));
         txn_manager_->Commit(original_txn, transaction::TransactionUtil::EmptyCallback, nullptr);

--- a/test/storage/sql_table_test.cpp
+++ b/test/storage/sql_table_test.cpp
@@ -17,6 +17,118 @@ struct SqlTableTests : public TerrierTest {
   std::uniform_real_distribution<double> null_ratio_{0.0, 1.0};
 };
 
+class RandomSqlTableTestObject {
+ public:
+  template <class Random>
+  RandomSqlTableTestObject(storage::BlockStore *block_store, const uint16_t max_col, Random *generator,
+                           double null_bias)
+      : null_bias_(null_bias) {
+    auto schema = StorageTestUtil::RandomSchemaNoVarlen(max_col, generator);
+    table_ = std::make_unique<storage::SqlTable>(common::ManagedPointer<storage::BlockStore>(block_store), *schema);
+    auto columns = schema->GetColumns();
+    std::vector<catalog::col_oid_t> oids;
+    oids.reserve(columns.size());
+    for (auto &col : columns) {
+      oids.push_back(col.Oid());
+    }
+    auto pri = table_->InitializerForProjectedRow(oids, storage::layout_version_t{0});
+
+    // ProjectedRowInitilzier and SelectBuffers
+    pris_ = {{storage::layout_version_t{0}, pri}};
+    buffers_ = {{storage::layout_version_t{0}, common::AllocationUtil::AllocateAligned(pri.ProjectedRowSize())}};
+    schemas_.emplace_back(schema);
+  }
+
+  template <class Random>
+  storage::TupleSlot InsertRandomTuple(const transaction::timestamp_t timestamp, Random *generator,
+                                       storage::RecordBufferSegmentPool *buffer_pool,
+                                       storage::layout_version_t layout_version) {
+    // generate a txn with an UndoRecord to populate on Insert
+    auto *txn =
+        new transaction::TransactionContext(timestamp, timestamp, common::ManagedPointer(buffer_pool), DISABLED);
+    txns_.emplace_back(txn);
+
+    // generate a random ProjectedRow to Insert
+    auto redo_initilizer = pris_.at(layout_version);
+    auto *const insert_redo = txn->StageWrite(catalog::db_oid_t{0}, catalog::table_oid_t{0}, redo_initilizer);
+    auto *const insert_tuple = insert_redo->Delta();
+    auto layout = table_->GetBlockLayout(layout_version);
+    StorageTestUtil::PopulateRandomRow(insert_tuple, layout, null_bias_, generator);
+
+    redos_.emplace_back(insert_redo);
+    storage::TupleSlot slot = table_->Insert(common::ManagedPointer(txn), insert_redo);
+    inserted_slots_.push_back(slot);
+    tuple_versions_[slot].emplace_back(timestamp, insert_tuple);
+
+    return slot;
+  }
+
+  const storage::ProjectedRow *GetReferenceVersionedTuple(const storage::TupleSlot slot,
+                                                          const transaction::timestamp_t timestamp) {
+    TERRIER_ASSERT(tuple_versions_.find(slot) != tuple_versions_.end(), "Slot not found.");
+    auto &versions = tuple_versions_[slot];
+    // search backwards so the first entry with smaller timestamp can be returned
+    for (auto i = static_cast<int64_t>(versions.size() - 1); i >= 0; i--)
+      if (transaction::TransactionUtil::NewerThan(timestamp, versions[i].first) || timestamp == versions[i].first)
+        return versions[i].second;
+    return nullptr;
+  }
+
+  storage::ProjectedRow *Select(const storage::TupleSlot slot, const transaction::timestamp_t timestamp,
+                                storage::RecordBufferSegmentPool *buffer_pool,
+                                storage::layout_version_t layout_version) {
+    auto *txn =
+        new transaction::TransactionContext(timestamp, timestamp, common::ManagedPointer(buffer_pool), DISABLED);
+    txns_.emplace_back(txn);
+
+    // generate a redo ProjectedRow for Select
+    storage::ProjectedRow *select_row = pris_.at(layout_version).InitializeRow(buffers_.at(layout_version));
+    table_->Select(common::ManagedPointer(txn), slot, select_row, layout_version);
+    return select_row;
+  }
+
+  const std::vector<storage::TupleSlot> &InsertedTuples() const { return inserted_slots_; }
+
+  storage::BlockLayout GetBlockLayout(storage::layout_version_t version) const {
+    return table_->GetBlockLayout(version);
+  }
+
+ private:
+  std::unique_ptr<storage::SqlTable> table_;
+  double null_bias_;
+  std::unordered_map<storage::layout_version_t, storage::ProjectedRowInitializer> pris_;
+  std::unordered_map<storage::layout_version_t, byte *> buffers_;
+  std::vector<common::ManagedPointer<storage::RedoRecord>> redos_;
+  std::vector<std::unique_ptr<transaction::TransactionContext>> txns_;
+  std::vector<storage::TupleSlot> inserted_slots_;
+  using tuple_version = std::pair<transaction::timestamp_t, storage::ProjectedRow *>;
+  // oldest to newest
+  std::unordered_map<storage::TupleSlot, std::vector<tuple_version>> tuple_versions_;
+  std::vector<std::unique_ptr<catalog::Schema>> schemas_;
+};
+
 // NOLINTNEXTLINE
-TEST_F(SqlTableTests, SimpleInsert) { EXPECT_TRUE(1 == 1); }
+TEST_F(SqlTableTests, SimpleInsertSelect) {
+  const uint16_t max_columns = 20;
+  const uint32_t num_inserts = 100;
+
+  storage::layout_version_t version(0);
+
+  // Insert into SqlTable
+  RandomSqlTableTestObject test_table(&block_store_, max_columns, &generator_, null_ratio_(generator_));
+  for (uint16_t i = 0; i < num_inserts; i++) {
+    test_table.InsertRandomTuple(transaction::timestamp_t(0), &generator_, &buffer_pool_, version);
+  }
+
+  EXPECT_EQ(num_inserts, test_table.InsertedTuples().size());
+
+  // Compare each inserted
+  for (const auto &inserted_tuple : test_table.InsertedTuples()) {
+    storage::ProjectedRow *stored =
+        test_table.Select(inserted_tuple, transaction::timestamp_t(1), &buffer_pool_, version);
+    const storage::ProjectedRow *ref =
+        test_table.GetReferenceVersionedTuple(inserted_tuple, transaction::timestamp_t(1));
+    EXPECT_TRUE(StorageTestUtil::ProjectionListEqualShallow(test_table.GetBlockLayout(version), stored, ref));
+  }
+}
 }  // namespace terrier

--- a/test/storage/sql_table_test.cpp
+++ b/test/storage/sql_table_test.cpp
@@ -1,0 +1,22 @@
+#include "storage/sql_table.h"
+
+#include <cstring>
+#include <vector>
+
+#include "storage/storage_util.h"
+#include "test_util/storage_test_util.h"
+#include "test_util/test_harness.h"
+#include "transaction/transaction_context.h"
+
+namespace terrier {
+
+struct SqlTableTests : public TerrierTest {
+  storage::BlockStore block_store_{100, 100};
+  storage::RecordBufferSegmentPool buffer_pool_{100000, 10000};
+  std::default_random_engine generator_;
+  std::uniform_real_distribution<double> null_ratio_{0.0, 1.0};
+};
+
+// NOLINTNEXTLINE
+TEST_F(SqlTableTests, SimpleInsert) { EXPECT_TRUE(1 == 1); }
+}  // namespace terrier

--- a/test/storage/sql_table_test.cpp
+++ b/test/storage/sql_table_test.cpp
@@ -17,26 +17,43 @@ struct SqlTableTests : public TerrierTest {
   std::uniform_real_distribution<double> null_ratio_{0.0, 1.0};
 };
 
+
+static std::unique_ptr<catalog::Schema> AddColumn(const catalog::Schema &schema, catalog::Schema::Column column) {
+  std::vector<catalog::Schema::Column> new_columns(schema.GetColumns());
+  std::vector<catalog::col_oid_t> oids;
+  oids.reserve(new_columns.size() + 1);
+  catalog::col_oid_t next_oid = new_columns.begin()->Oid();
+  for(auto &col: new_columns) {
+    if (col.Oid() > next_oid) {
+      next_oid = col.Oid();
+    }
+  }
+  next_oid = next_oid + 1;
+  StorageTestUtil::SetOid(column, next_oid);
+  new_columns.push_back(column);
+  return std::unique_ptr<catalog::Schema>(new catalog::Schema(new_columns));
+}
+
 class RandomSqlTableTestObject {
  public:
+  struct tuple_version {
+    transaction::timestamp_t ts_;
+    storage::ProjectedRow * pr_;
+    storage::layout_version_t version_;
+  };
+
+
   template <class Random>
   RandomSqlTableTestObject(storage::BlockStore *block_store, const uint16_t max_col, Random *generator,
                            double null_bias)
       : null_bias_(null_bias) {
     auto schema = StorageTestUtil::RandomSchemaNoVarlen(max_col, generator);
     table_ = std::make_unique<storage::SqlTable>(common::ManagedPointer<storage::BlockStore>(block_store), *schema);
-    auto columns = schema->GetColumns();
-    std::vector<catalog::col_oid_t> oids;
-    oids.reserve(columns.size());
-    for (auto &col : columns) {
-      oids.push_back(col.Oid());
-    }
-    auto pri = table_->InitializerForProjectedRow(oids, storage::layout_version_t{0});
+    UpdateSchema({nullptr}, std::unique_ptr<catalog::Schema>(schema), storage::layout_version_t(0));
+  }
 
-    // ProjectedRowInitilzier and SelectBuffers
-    pris_ = {{storage::layout_version_t{0}, pri}};
-    buffers_ = {{storage::layout_version_t{0}, common::AllocationUtil::AllocateAligned(pri.ProjectedRowSize())}};
-    schemas_.emplace_back(schema);
+  ~RandomSqlTableTestObject() {
+    // redos_ seems to be producing problem here
   }
 
   template <class Random>
@@ -50,28 +67,29 @@ class RandomSqlTableTestObject {
 
     // generate a random ProjectedRow to Insert
     auto redo_initilizer = pris_.at(layout_version);
-    auto *const insert_redo = txn->StageWrite(catalog::db_oid_t{0}, catalog::table_oid_t{0}, redo_initilizer);
-    auto *const insert_tuple = insert_redo->Delta();
+    auto *insert_redo = txn->StageWrite(catalog::db_oid_t{0}, catalog::table_oid_t{0}, redo_initilizer);
+    auto *insert_tuple = insert_redo->Delta();
     auto layout = table_->GetBlockLayout(layout_version);
     StorageTestUtil::PopulateRandomRow(insert_tuple, layout, null_bias_, generator);
 
     redos_.emplace_back(insert_redo);
     storage::TupleSlot slot = table_->Insert(common::ManagedPointer(txn), insert_redo);
     inserted_slots_.push_back(slot);
-    tuple_versions_[slot].emplace_back(timestamp, insert_tuple);
+    tuple_versions_[slot].push_back({timestamp, insert_tuple, layout_version});
 
     return slot;
   }
 
-  const storage::ProjectedRow *GetReferenceVersionedTuple(const storage::TupleSlot slot,
+  tuple_version GetReferenceVersionedTuple(const storage::TupleSlot slot,
                                                           const transaction::timestamp_t timestamp) {
     TERRIER_ASSERT(tuple_versions_.find(slot) != tuple_versions_.end(), "Slot not found.");
     auto &versions = tuple_versions_[slot];
     // search backwards so the first entry with smaller timestamp can be returned
     for (auto i = static_cast<int64_t>(versions.size() - 1); i >= 0; i--)
-      if (transaction::TransactionUtil::NewerThan(timestamp, versions[i].first) || timestamp == versions[i].first)
-        return versions[i].second;
-    return nullptr;
+      if (transaction::TransactionUtil::NewerThan(timestamp, versions[i].ts_) || timestamp == versions[i].ts_)
+        return versions[i];
+    return {transaction::timestamp_t{transaction::INVALID_TXN_TIMESTAMP},nullptr,
+            storage::layout_version_t {0}};
   }
 
   storage::ProjectedRow *Select(const storage::TupleSlot slot, const transaction::timestamp_t timestamp,
@@ -87,10 +105,46 @@ class RandomSqlTableTestObject {
     return select_row;
   }
 
+  void UpdateSchema(common::ManagedPointer<transaction::TransactionContext> txn, std::unique_ptr<catalog::Schema> schema, const storage::layout_version_t layout_version) {
+    if(txn != nullptr) table_->UpdateSchema(txn, *schema, layout_version);
+
+    auto columns = schema->GetColumns();
+    std::vector<catalog::col_oid_t> oids;
+    oids.reserve(columns.size());
+    for (auto &col : columns) {
+      oids.push_back(col.Oid());
+    }
+    auto pri = table_->InitializerForProjectedRow(oids, layout_version);
+    schemas_.insert(std::make_pair(layout_version, std::unique_ptr<catalog::Schema>(std::move(schema))));
+    pris_.insert(std::make_pair(layout_version, pri));
+    buffers_.insert(std::make_pair(layout_version, common::AllocationUtil::AllocateAligned(pri.ProjectedRowSize())));
+  }
+
+  common::ManagedPointer<transaction::TransactionContext> NewTransaction(transaction::timestamp_t timestamp,
+      storage::RecordBufferSegmentPool *buffer_pool) {
+    auto *txn =
+        new transaction::TransactionContext(timestamp, timestamp, common::ManagedPointer(buffer_pool), DISABLED);
+    txns_.emplace_back(txn);
+    return common::ManagedPointer<transaction::TransactionContext>(txn);
+  }
+
   const std::vector<storage::TupleSlot> &InsertedTuples() const { return inserted_slots_; }
 
   storage::BlockLayout GetBlockLayout(storage::layout_version_t version) const {
     return table_->GetBlockLayout(version);
+  }
+
+  const catalog::Schema &GetSchema(storage::layout_version_t version) const {
+    return *schemas_.at(version);
+  }
+
+  storage::ProjectionMap GetProjectionMapForOids(storage::layout_version_t version) {
+    auto &schema = schemas_.at(version);
+    auto columns = schema->GetColumns();
+    std::vector<catalog::col_oid_t> oids;
+    oids.reserve(columns.size());
+    for(auto &col : columns) oids.push_back(col.Oid());
+    return table_->ProjectionMapForOids(oids, version);
   }
 
  private:
@@ -101,10 +155,9 @@ class RandomSqlTableTestObject {
   std::vector<common::ManagedPointer<storage::RedoRecord>> redos_;
   std::vector<std::unique_ptr<transaction::TransactionContext>> txns_;
   std::vector<storage::TupleSlot> inserted_slots_;
-  using tuple_version = std::pair<transaction::timestamp_t, storage::ProjectedRow *>;
   // oldest to newest
   std::unordered_map<storage::TupleSlot, std::vector<tuple_version>> tuple_versions_;
-  std::vector<std::unique_ptr<catalog::Schema>> schemas_;
+  std::unordered_map<storage::layout_version_t , std::unique_ptr<catalog::Schema>> schemas_;
 };
 
 // NOLINTNEXTLINE
@@ -126,9 +179,64 @@ TEST_F(SqlTableTests, SimpleInsertSelect) {
   for (const auto &inserted_tuple : test_table.InsertedTuples()) {
     storage::ProjectedRow *stored =
         test_table.Select(inserted_tuple, transaction::timestamp_t(1), &buffer_pool_, version);
-    const storage::ProjectedRow *ref =
-        test_table.GetReferenceVersionedTuple(inserted_tuple, transaction::timestamp_t(1));
+    auto *ref =
+        test_table.GetReferenceVersionedTuple(inserted_tuple, transaction::timestamp_t(1)).pr_;
+
     EXPECT_TRUE(StorageTestUtil::ProjectionListEqualShallow(test_table.GetBlockLayout(version), stored, ref));
   }
 }
+
+// NOLINTNEXTLINE
+TEST_F(SqlTableTests, DISABLED_SimpleAddColumnTest) {
+  const uint16_t max_columns = 20;
+  const uint32_t num_inserts = 100;
+  uint64_t txn_ts = 0;
+
+  storage::layout_version_t version(0);
+
+  // Insert first half into SqlTable
+  RandomSqlTableTestObject test_table(&block_store_, max_columns, &generator_, null_ratio_(generator_));
+  for (uint16_t i = 0; i < num_inserts / 2; i++) {
+    test_table.InsertRandomTuple(transaction::timestamp_t(txn_ts), &generator_, &buffer_pool_, version);
+  }
+
+  EXPECT_EQ(num_inserts / 2, test_table.InsertedTuples().size());
+
+
+  // Schema Update with column added
+  storage::layout_version_t new_version(1);
+  txn_ts++;
+  catalog::Schema::Column col("new_col", type::TypeId::INTEGER, false,
+      parser::ConstantValueExpression(type::TransientValueFactory::GetInteger(1)));
+  auto new_schema = AddColumn(test_table.GetSchema(version), col);
+  test_table.UpdateSchema(test_table.NewTransaction(transaction::timestamp_t{txn_ts},
+                                                    &buffer_pool_), std::move(new_schema), new_version);
+
+  // Insert the second half with new version
+  txn_ts++;
+  for (uint16_t i = num_inserts / 2 ; i < num_inserts; i++) {
+    test_table.InsertRandomTuple(transaction::timestamp_t(txn_ts), &generator_, &buffer_pool_, new_version);
+  }
+
+
+  EXPECT_EQ(num_inserts, test_table.InsertedTuples().size());
+  // Compare each inserted
+  txn_ts++;
+  std::unordered_set<catalog::col_oid_t> add_cols;
+  std::unordered_set<catalog::col_oid_t> drop_cols{col.Oid()};
+  for (const auto &inserted_tuple : test_table.InsertedTuples()) {
+    storage::ProjectedRow *stored =
+        test_table.Select(inserted_tuple, transaction::timestamp_t(txn_ts), &buffer_pool_, version);
+    auto tuple_version =
+        test_table.GetReferenceVersionedTuple(inserted_tuple, transaction::timestamp_t(txn_ts));
+    //TODO(Schema-change): we need to find a way to compare these 2 projected rows with different schema/blocklayout with
+    // other schema changes. e.g: change column type, add constrain.
+    EXPECT_TRUE(StorageTestUtil::ProjectionListEqualShallowMatchSchema(
+        test_table.GetBlockLayout(tuple_version.version_), tuple_version.pr_, test_table.GetProjectionMapForOids(tuple_version.version_),
+        test_table.GetBlockLayout(version), stored, test_table.GetProjectionMapForOids(version),
+        add_cols, drop_cols));
+  }
+}
+
+
 }  // namespace terrier

--- a/test/test_util/sql_table_test_util.cpp
+++ b/test/test_util/sql_table_test_util.cpp
@@ -59,7 +59,7 @@ void RandomSqlTableTransaction::RandomUpdate(Random *generator) {
   record->SetTupleSlot(updated);
   StorageTestUtil::PopulateRandomRow(record->Delta(), sql_table_ptr->tables_.begin()->second.layout_, 0.0, generator);
   auto result = sql_table_ptr->Update(common::ManagedPointer(txn_), record);
-  aborted_ = !result;
+  aborted_ = !result.first;
 }
 
 template <class Random>

--- a/test/test_util/sql_table_test_util.cpp
+++ b/test/test_util/sql_table_test_util.cpp
@@ -24,7 +24,7 @@ void RandomSqlTableTransaction::RandomInsert(Random *generator) {
   // Generate random insert
   auto initializer = sql_table_ptr->InitializerForProjectedRow(sql_table_metadata->col_oids_);
   auto *const record = txn_->StageWrite(database_oid, table_oid, initializer);
-  StorageTestUtil::PopulateRandomRow(record->Delta(), sql_table_ptr->table_.layout_, 0.0, generator);
+  StorageTestUtil::PopulateRandomRow(record->Delta(), sql_table_ptr->tables_.begin()->second.layout_, 0.0, generator);
   record->SetTupleSlot(storage::TupleSlot(nullptr, 0));
   auto tuple_slot = sql_table_ptr->Insert(common::ManagedPointer(txn_), record);
 
@@ -57,7 +57,7 @@ void RandomSqlTableTransaction::RandomUpdate(Random *generator) {
       StorageTestUtil::RandomNonEmptySubset(sql_table_metadata->col_oids_, generator));
   auto *const record = txn_->StageWrite(database_oid, table_oid, initializer);
   record->SetTupleSlot(updated);
-  StorageTestUtil::PopulateRandomRow(record->Delta(), sql_table_ptr->table_.layout_, 0.0, generator);
+  StorageTestUtil::PopulateRandomRow(record->Delta(), sql_table_ptr->tables_.begin()->second.layout_, 0.0, generator);
   auto result = sql_table_ptr->Update(common::ManagedPointer(txn_), record);
   aborted_ = !result;
 }
@@ -253,7 +253,7 @@ void LargeSqlTableTestObject::PopulateInitialTables(uint16_t num_databases, uint
       std::vector<storage::TupleSlot> inserted_tuples;
       for (uint32_t i = 0; i < num_tuples; i++) {
         auto *const redo = initial_txn_->StageWrite(database_oid, table_oid, initializer);
-        StorageTestUtil::PopulateRandomRow(redo->Delta(), sql_table->table_.layout_, 0.0, generator);
+        StorageTestUtil::PopulateRandomRow(redo->Delta(), sql_table->tables_.begin()->second.layout_, 0.0, generator);
         const storage::TupleSlot inserted = sql_table->Insert(common::ManagedPointer(initial_txn_), redo);
         inserted_tuples.emplace_back(inserted);
       }

--- a/test/test_util/tpcc/delivery.cpp
+++ b/test/test_util/tpcc/delivery.cpp
@@ -83,7 +83,7 @@ bool Delivery::Execute(transaction::TransactionManager *const txn_manager, Datab
     auto *const order_update_redo = txn->StageWrite(db->db_oid_, db->order_table_oid_, order_update_pr_initializer_);
     *reinterpret_cast<int8_t *>(order_update_redo->Delta()->AccessForceNotNull(0)) = args.o_carrier_id_;
     order_update_redo->SetTupleSlot(order_slot);
-    bool update_result UNUSED_ATTRIBUTE = db->order_table_->Update(common::ManagedPointer(txn), order_update_redo);
+    bool update_result UNUSED_ATTRIBUTE = db->order_table_->Update(common::ManagedPointer(txn), order_update_redo).first;
     TERRIER_ASSERT(select_result,
                    "Order update failed. This assertion assumes 1:1 mapping between warehouse and workers.");
 
@@ -125,7 +125,7 @@ bool Delivery::Execute(transaction::TransactionManager *const txn_manager, Datab
           txn->StageWrite(db->db_oid_, db->order_line_table_oid_, order_line_update_pr_initializer_);
       *reinterpret_cast<uint64_t *>(order_line_update_redo->Delta()->AccessForceNotNull(0)) = args.ol_delivery_d_;
       order_line_update_redo->SetTupleSlot(order_line_slot);
-      update_result = db->order_line_table_->Update(common::ManagedPointer(txn), order_line_update_redo);
+      update_result = db->order_line_table_->Update(common::ManagedPointer(txn), order_line_update_redo).first;
       TERRIER_ASSERT(update_result,
                      "Order Line update failed. This assertion assumes 1:1 mapping between warehouse and workers.");
     }
@@ -153,7 +153,7 @@ bool Delivery::Execute(transaction::TransactionManager *const txn_manager, Datab
     *reinterpret_cast<double *>(customer_update_tuple->AccessForceNotNull(c_balance_pr_offset_)) += ol_amount_sum;
     (*reinterpret_cast<int16_t *>(customer_update_tuple->AccessForceNotNull(c_delivery_cnt_pr_offset_)))++;
     customer_update_redo->SetTupleSlot(index_scan_results[0]);
-    update_result = db->customer_table_->Update(common::ManagedPointer(txn), customer_update_redo);
+    update_result = db->customer_table_->Update(common::ManagedPointer(txn), customer_update_redo).first;
     TERRIER_ASSERT(update_result,
                    "Customer update failed. This assertion assumes 1:1 mapping between warehouse and workers.");
   }

--- a/test/test_util/tpcc/new_order.cpp
+++ b/test/test_util/tpcc/new_order.cpp
@@ -59,7 +59,7 @@ bool NewOrder::Execute(transaction::TransactionManager *const txn_manager, Datab
       txn->StageWrite(db->db_oid_, db->district_table_oid_, district_update_pr_initializer_);
   *reinterpret_cast<int32_t *>(district_update_redo->Delta()->AccessForceNotNull(0)) = d_next_o_id + 1;
   district_update_redo->SetTupleSlot(index_scan_results[0]);
-  bool UNUSED_ATTRIBUTE result = db->district_table_->Update(common::ManagedPointer(txn), district_update_redo);
+  bool UNUSED_ATTRIBUTE result = db->district_table_->Update(common::ManagedPointer(txn), district_update_redo).first;
   TERRIER_ASSERT(result, "District update failed. This assertion assumes 1:1 mapping between warehouse and workers.");
 
   // Look up C_ID, D_ID, W_ID in index
@@ -217,7 +217,7 @@ bool NewOrder::Execute(transaction::TransactionManager *const txn_manager, Datab
     *reinterpret_cast<int16_t *>(stock_update_tuple->AccessForceNotNull(s_remote_cnt_update_pr_offset_)) =
         static_cast<int16_t>(item.remote_ ? s_remote_cnt + 1 : s_remote_cnt);
     stock_update_redo->SetTupleSlot(index_scan_results[0]);
-    result = db->stock_table_->Update(common::ManagedPointer(txn), stock_update_redo);
+    result = db->stock_table_->Update(common::ManagedPointer(txn), stock_update_redo).first;
     if (!result) {
       // This can fail due to remote orders
       txn_manager->Abort(txn);

--- a/test/test_util/tpcc/payment.cpp
+++ b/test/test_util/tpcc/payment.cpp
@@ -39,7 +39,7 @@ bool Payment::Execute(transaction::TransactionManager *const txn_manager, Databa
       txn->StageWrite(db->db_oid_, db->warehouse_table_oid_, warehouse_update_pr_initializer_);
   *reinterpret_cast<double *>(warehouse_update_redo->Delta()->AccessForceNotNull(0)) = w_ytd + args.h_amount_;
   warehouse_update_redo->SetTupleSlot(index_scan_results[0]);
-  bool UNUSED_ATTRIBUTE result = db->warehouse_table_->Update(common::ManagedPointer(txn), warehouse_update_redo);
+  bool UNUSED_ATTRIBUTE result = db->warehouse_table_->Update(common::ManagedPointer(txn), warehouse_update_redo).first;
   TERRIER_ASSERT(result, "Warehouse update failed. This assertion assumes 1:1 mapping between warehouse and workers.");
 
   // Look up D_ID, W_ID in index
@@ -68,7 +68,7 @@ bool Payment::Execute(transaction::TransactionManager *const txn_manager, Databa
       txn->StageWrite(db->db_oid_, db->district_table_oid_, district_update_pr_initializer_);
   *reinterpret_cast<double *>(district_update_redo->Delta()->AccessForceNotNull(0)) = d_ytd + args.h_amount_;
   district_update_redo->SetTupleSlot(index_scan_results[0]);
-  result = db->district_table_->Update(common::ManagedPointer(txn), district_update_redo);
+  result = db->district_table_->Update(common::ManagedPointer(txn), district_update_redo).first;
   TERRIER_ASSERT(result, "District update failed. This assertion assumes 1:1 mapping between warehouse and workers.");
 
   storage::TupleSlot customer_slot;
@@ -151,7 +151,7 @@ bool Payment::Execute(transaction::TransactionManager *const txn_manager, Databa
   *reinterpret_cast<int16_t *>(customer_update_tuple->AccessForceNotNull(c_payment_cnt_update_pr_offset_)) =
       static_cast<int16_t>(c_payment_cnt + 1);
   customer_update_redo->SetTupleSlot(customer_slot);
-  result = db->customer_table_->Update(common::ManagedPointer(txn), customer_update_redo);
+  result = db->customer_table_->Update(common::ManagedPointer(txn), customer_update_redo).first;
   TERRIER_ASSERT(result, "Customer update failed. This assertion assumes 1:1 mapping between warehouse and workers.");
 
   const auto c_credit_str = c_credit.StringView();
@@ -176,7 +176,7 @@ bool Payment::Execute(transaction::TransactionManager *const txn_manager, Databa
     *reinterpret_cast<storage::VarlenEntry *>(c_data_update_redo->Delta()->AccessForceNotNull(0)) = varlen_entry;
 
     c_data_update_redo->SetTupleSlot(customer_slot);
-    result = db->customer_table_->Update(common::ManagedPointer(txn), c_data_update_redo);
+    result = db->customer_table_->Update(common::ManagedPointer(txn), c_data_update_redo).first;
     TERRIER_ASSERT(result, "Customer update failed. This assertion assumes 1:1 mapping between warehouse and workers.");
   }
 


### PR DESCRIPTION
PR to code review for status update:
1. Changes Sqltable to support multiple versions and multiple datatables. Can add/drop columns, while maintaining correctness of Sqltable::insert/delete/scan/select
2. Sqltable supports single-threaded schema changes (still some bugs in tests).
3. Unit tests for Sqltable, testing adding columns.
4. Design doc for status update