### PR TITLE
for concurrent

### DIFF
--- a/src/include/storage/sql_table.h
+++ b/src/include/storage/sql_table.h
@@ -265,7 +265,8 @@ class SqlTable {
    * @return the column id to oid map of a layout_version
    */
   const ColumnIdToOidMap &GetColumnIdToOidMap(layout_version_t layout_version) const {
-    TERRIER_ASSERT(layout_version < 8 && tables_[layout_version].data_table_ != nullptr, "Version does not exist.");
+    TERRIER_ASSERT(layout_version < MAX_NUM_OF_VERSIONS && tables_[layout_version].data_table_ != nullptr,
+                   "Version does not exist.");
     return tables_.at(layout_version).column_id_to_oid_map_;
   }
 
@@ -276,7 +277,8 @@ class SqlTable {
    * @return
    */
   const BlockLayout &GetBlockLayout(layout_version_t layout_version = layout_version_t{0}) {
-    TERRIER_ASSERT(layout_version < 8 && tables_[layout_version].data_table_ != nullptr, "Version does not exist.");
+    TERRIER_ASSERT(layout_version < MAX_NUM_OF_VERSIONS && tables_[layout_version].data_table_ != nullptr,
+                   "Version does not exist.");
     return tables_.at(layout_version).layout_;
   }
 
@@ -293,7 +295,7 @@ class SqlTable {
   //  when layout version is not monotonically increasing from 0;
   //  for example, when we implement garbage collecting empty old datatable, or when we collapse versions
   //  We could potentially used ordered map for traversing data table that are less or equal to curr version
-  // Vector of tables with fixed size of 8
+  // Vector of tables with fixed size of MAX_NUM_OF_VERSIONS
   //  We could later see if a unbounded concurrent vector greatly a affect the performance
   std::vector<DataTableVersion> tables_;
 

--- a/src/include/storage/sql_table.h
+++ b/src/include/storage/sql_table.h
@@ -45,7 +45,7 @@ class SqlTable {
     //  Consider storing forward and backward delta of the schema change maybe in the future
     ColumnIdToOidMap column_id_to_oid_map_;
     common::ManagedPointer<const catalog::Schema> schema_;
-    const DefaultValueMap default_value_map_;
+    DefaultValueMap default_value_map_;
   };
 
  public:
@@ -62,7 +62,7 @@ class SqlTable {
    * Destructs a SqlTable, frees all its member datatables.
    */
   ~SqlTable() {
-    for (const auto &it : tables_) delete it.second.data_table_;
+    for (const auto &it : tables_) delete it.data_table_;
   }
 
   /**
@@ -157,13 +157,10 @@ class SqlTable {
    * @param layout_version Version number for the new schema
    * @param schema the updated schema of this SqlTable
    */
-  void UpdateSchema(const common::ManagedPointer<transaction::TransactionContext> txn, const catalog::Schema &schema,
+  bool UpdateSchema(const common::ManagedPointer<transaction::TransactionContext> txn, const catalog::Schema &schema,
                     const layout_version_t layout_version = layout_version_t{0}) {
-    TERRIER_ASSERT(tables_.lower_bound(layout_version) == tables_.end(),
-                   "input version should be strictly larger than all versions");
-    auto table = CreateTable(common::ManagedPointer<const catalog::Schema>(&schema), block_store_, layout_version);
-    const auto UNUSED_ATTRIBUTE[it, success] = tables_.insert(std::make_pair(layout_version, table));
-    TERRIER_ASSERT(it != tables_.end() && success, "inserting new tableversion should not fail");
+    TERRIER_ASSERT(layout_version == num_of_versions_, "lalaInput version should be strictly larger than all versions");
+    return CreateTable(common::ManagedPointer<const catalog::Schema>(&schema), layout_version);
   }
 
   // TODO(Schema-Change): Do we retain the begin() and end(), or implement begin and end function with version number?
@@ -174,7 +171,7 @@ class SqlTable {
   // NOLINTNEXTLINE for STL name compability
   DataTable::SlotIterator begin() const {
     TERRIER_ASSERT(!tables_.empty(), "sqltable should have at least one underlying datatable");
-    return tables_.begin()->second.data_table_->begin();
+    return tables_.begin()->data_table_->begin();
   }
 
   /**
@@ -183,7 +180,7 @@ class SqlTable {
   // NOLINTNEXTLINE for STL name compability
   DataTable::SlotIterator end() const {
     TERRIER_ASSERT(!tables_.empty(), "sqltable should have at least one underlying datatable");
-    return std::prev(tables_.end())->second.data_table_->end();
+    return tables_[num_of_versions_ - 1].data_table_->end();
   }  // NOLINT for STL name compability
 
   /**
@@ -258,18 +255,18 @@ class SqlTable {
    * @param version  version of the datatable
    * @return the column oid to id map of a layout_version
    */
-  const ColumnOidToIdMap &GetColumnOidToIdMap(layout_version_t version) const {
-    TERRIER_ASSERT(tables_.count(version) > 0, "version not existing..");
-    return tables_.at(version).column_oid_to_id_map_;
+  const ColumnOidToIdMap &GetColumnOidToIdMap(layout_version_t layout_version) const {
+    TERRIER_ASSERT(layout_version < num_of_versions_, "Version does not exist.");
+    return tables_.at(layout_version).column_oid_to_id_map_;
   }
 
   /**
    * @param version  version of the datatable
    * @return the column id to oid map of a layout_version
    */
-  const ColumnIdToOidMap &GetColumnIdToOidMap(layout_version_t version) const {
-    TERRIER_ASSERT(tables_.count(version) > 0, "version not existing..");
-    return tables_.at(version).column_id_to_oid_map_;
+  const ColumnIdToOidMap &GetColumnIdToOidMap(layout_version_t layout_version) const {
+    TERRIER_ASSERT(layout_version < 8 && tables_[layout_version].data_table_ != nullptr, "Version does not exist.");
+    return tables_.at(layout_version).column_id_to_oid_map_;
   }
 
   /**
@@ -279,6 +276,7 @@ class SqlTable {
    * @return
    */
   const BlockLayout &GetBlockLayout(layout_version_t layout_version = layout_version_t{0}) {
+    TERRIER_ASSERT(layout_version < 8 && tables_[layout_version].data_table_ != nullptr, "Version does not exist.");
     return tables_.at(layout_version).layout_;
   }
 
@@ -288,13 +286,18 @@ class SqlTable {
   friend class terrier::LargeSqlTableTestObject;
   friend class RecoveryTests;
 
-  const common::ManagedPointer<BlockStore>
-      block_store_;  // TODO(Matt): do we need this stashed at this layer? We don't use it.
+  // TODO(Matt): do we need this stashed at this layer? We don't use it.
+  const common::ManagedPointer<BlockStore> block_store_;
 
-  // Eventually we'll support adding more tables when schema changes. For now we'll always access the one DataTable.
-  // TODO(Schema-Change): add concurrent access support. Implement single threaded version first
-  // Used ordered map for traversing data table that are less or equal to curr version
-  std::map<layout_version_t, DataTableVersion> tables_;
+  // TODO(Schema-Change): add concurrent layout version to dataTable lookup
+  //  when layout version is not monotonically increasing from 0;
+  //  for example, when we implement garbage collecting empty old datatable, or when we collapse versions
+  //  We could potentially used ordered map for traversing data table that are less or equal to curr version
+  // Vector of tables with fixed size of 8
+  //  We could later see if a unbounded concurrent vector greatly a affect the performance
+  std::vector<DataTableVersion> tables_;
+
+  std::atomic<uint8_t> num_of_versions_ = 0;
 
   /**
    * Translates out_buffer from desired version col_ids to tuple version col_ids, by mapping each col_id in out_buffer
@@ -326,12 +329,10 @@ class SqlTable {
   /**
    * Creates a new datatble version given the schema and version number
    * @param schema the initial Schema of this SqlTable
-   * @param store the Block store to use.
    * @param version Schema version of the created/updated table version
-   * @return DataTableVersion
+   * @return If the datatable version has been successfully created
    */
-  DataTableVersion CreateTable(common::ManagedPointer<const catalog::Schema> schema,
-                               common::ManagedPointer<BlockStore> store, layout_version_t version);
+  bool CreateTable(common::ManagedPointer<const catalog::Schema> schema, layout_version_t version);
 
   /**
    * Given a set of col_oids, return a vector of corresponding col_ids to use for ProjectionInitialization

--- a/src/include/storage/storage_defs.h
+++ b/src/include/storage/storage_defs.h
@@ -34,7 +34,10 @@ namespace terrier::storage {
 constexpr uint8_t NUM_ATTR_BOUNDARIES = 4;
 
 STRONG_TYPEDEF(col_id_t, uint16_t);
-STRONG_TYPEDEF(layout_version_t, uint16_t);
+using layout_version_t = uint16_t;
+
+// TODO(Schema-Change): only allow a maximum of 8 versions per schema; extend it to arbitrary version later
+constexpr uint8_t MAX_NUM_OF_VERSIONS = 8;
 
 // All tuples potentially visible to txns should have a non-null attribute of version vector.
 // This is not to be confused with a non-null version vector that has value nullptr (0).

--- a/src/storage/sql_table.cpp
+++ b/src/storage/sql_table.cpp
@@ -14,11 +14,11 @@
 namespace terrier::storage {
 
 SqlTable::SqlTable(const common::ManagedPointer<BlockStore> store, const catalog::Schema &schema)
-    : block_store_(store) {
+    : block_store_(store), tables_(MAX_NUM_OF_VERSIONS, DataTableVersion()) {
   // Initialize a DataTable
-  tables_.clear();
-  tables_.insert(std::make_pair(layout_version_t(0), CreateTable(common::ManagedPointer<const catalog::Schema>(&schema),
-                                                                 store, layout_version_t(0))));
+  auto success UNUSED_ATTRIBUTE = CreateTable(common::ManagedPointer<const catalog::Schema>(&schema),
+                                              layout_version_t(0));
+  TERRIER_ASSERT(success, "Creating first data table should not fail.");
 }
 
 bool SqlTable::Select(const common::ManagedPointer<transaction::TransactionContext> txn, const TupleSlot slot,
@@ -321,10 +321,13 @@ template std::vector<std::pair<size_t, catalog::col_oid_t>> SqlTable::AlignHeade
     ProjectedColumns::RowView *const out_buffer, const DataTableVersion &tuple_version,
     const DataTableVersion &desired_version, col_id_t *cached_orig_header) const;
 
-SqlTable::DataTableVersion SqlTable::CreateTable(
-    const terrier::common::ManagedPointer<const terrier::catalog::Schema> schema,
-    const terrier::common::ManagedPointer<terrier::storage::BlockStore> store,
-    terrier::storage::layout_version_t version) {
+bool SqlTable::CreateTable(common::ManagedPointer<const catalog::Schema> schema, layout_version_t version) {
+  auto curr_num = ++num_of_versions_;
+  if (curr_num > MAX_NUM_OF_VERSIONS) {
+    num_of_versions_.store(MAX_NUM_OF_VERSIONS);
+    return false;
+  }
+
   // Begin with the NUM_RESERVED_COLUMNS in the attr_sizes
   std::vector<uint16_t> attr_sizes;
   attr_sizes.reserve(NUM_RESERVED_COLUMNS + schema->GetColumns().size());
@@ -342,46 +345,44 @@ SqlTable::DataTableVersion SqlTable::CreateTable(
 
   auto offsets = storage::StorageUtil::ComputeBaseAttributeOffsets(attr_sizes, NUM_RESERVED_COLUMNS);
 
-  ColumnOidToIdMap col_oid_to_id;
-  ColumnIdToOidMap col_id_to_oid;
-  DefaultValueMap default_value_map;
   // Build the map from Schema columns to underlying columns
   for (const auto &column : schema->GetColumns()) {
     auto default_value = column.StoredExpression();
     switch (column.AttrSize()) {
       case VARLEN_COLUMN:
-        if (default_value != nullptr) default_value_map[column.Oid()] = default_value;
-        col_id_to_oid[col_id_t(offsets[0])] = column.Oid();
-        col_oid_to_id[column.Oid()] = col_id_t(offsets[0]++);
+        if (default_value != nullptr) tables_[curr_num - 1].default_value_map_[column.Oid()] = default_value;
+        tables_[curr_num - 1].column_id_to_oid_map_[col_id_t(offsets[0])] = column.Oid();
+        tables_[curr_num - 1].column_oid_to_id_map_[column.Oid()] = col_id_t(offsets[0]++);
         break;
       case 8:
-        if (default_value != nullptr) default_value_map[column.Oid()] = default_value;
-        col_id_to_oid[col_id_t(offsets[1])] = column.Oid();
-        col_oid_to_id[column.Oid()] = col_id_t(offsets[1]++);
+        if (default_value != nullptr) tables_[curr_num - 1].default_value_map_[column.Oid()] = default_value;
+        tables_[curr_num - 1].column_id_to_oid_map_[col_id_t(offsets[1])] = column.Oid();
+        tables_[curr_num - 1].column_oid_to_id_map_[column.Oid()] = col_id_t(offsets[1]++);
         break;
       case 4:
-        if (default_value != nullptr) default_value_map[column.Oid()] = default_value;
-        col_id_to_oid[col_id_t(offsets[2])] = column.Oid();
-        col_oid_to_id[column.Oid()] = col_id_t(offsets[2]++);
+        if (default_value != nullptr) tables_[curr_num - 1].default_value_map_[column.Oid()] = default_value;
+        tables_[curr_num - 1].column_id_to_oid_map_[col_id_t(offsets[2])] = column.Oid();
+        tables_[curr_num - 1].column_oid_to_id_map_[column.Oid()] = col_id_t(offsets[2]++);
         break;
       case 2:
-        if (default_value != nullptr) default_value_map[column.Oid()] = default_value;
-        col_id_to_oid[col_id_t(offsets[3])] = column.Oid();
-        col_oid_to_id[column.Oid()] = col_id_t(offsets[3]++);
+        if (default_value != nullptr) tables_[curr_num - 1].default_value_map_[column.Oid()] = default_value;
+        tables_[curr_num - 1].column_id_to_oid_map_[col_id_t(offsets[3])] = column.Oid();
+        tables_[curr_num - 1].column_oid_to_id_map_[column.Oid()] = col_id_t(offsets[3]++);
         break;
       case 1:
-        if (default_value != nullptr) default_value_map[column.Oid()] = default_value;
-        col_id_to_oid[col_id_t(offsets[4])] = column.Oid();
-        col_oid_to_id[column.Oid()] = col_id_t(offsets[4]++);
+        if (default_value != nullptr) tables_[curr_num - 1].default_value_map_[column.Oid()] = default_value;
+        tables_[curr_num - 1].column_id_to_oid_map_[col_id_t(offsets[4])] = column.Oid();
+        tables_[curr_num - 1].column_oid_to_id_map_[column.Oid()] = col_id_t(offsets[4]++);
         break;
       default:
         throw std::runtime_error("unexpected switch case value");
     }
   }
 
-  auto layout = storage::BlockLayout(attr_sizes);
-  return {
-      new DataTable(block_store_, layout, version), layout, col_oid_to_id, col_id_to_oid, schema, default_value_map};
+  tables_[curr_num - 1].layout_ = storage::BlockLayout(attr_sizes);
+  tables_[curr_num - 1].schema_ = schema;
+  tables_[curr_num - 1].data_table_ = new DataTable(block_store_, tables_[curr_num - 1].layout_, version);
+  return true;
 }
 
 std::vector<col_id_t> SqlTable::ColIdsForOids(const std::vector<catalog::col_oid_t> &col_oids,

--- a/src/storage/sql_table.cpp
+++ b/src/storage/sql_table.cpp
@@ -16,8 +16,8 @@ namespace terrier::storage {
 SqlTable::SqlTable(const common::ManagedPointer<BlockStore> store, const catalog::Schema &schema)
     : block_store_(store), tables_(MAX_NUM_OF_VERSIONS, DataTableVersion()) {
   // Initialize a DataTable
-  auto success UNUSED_ATTRIBUTE = CreateTable(common::ManagedPointer<const catalog::Schema>(&schema),
-                                              layout_version_t(0));
+  auto success UNUSED_ATTRIBUTE =
+      CreateTable(common::ManagedPointer<const catalog::Schema>(&schema), layout_version_t(0));
   TERRIER_ASSERT(success, "Creating first data table should not fail.");
 }
 
@@ -333,7 +333,7 @@ bool SqlTable::CreateTable(common::ManagedPointer<const catalog::Schema> schema,
   attr_sizes.reserve(NUM_RESERVED_COLUMNS + schema->GetColumns().size());
 
   for (uint8_t i = 0; i < NUM_RESERVED_COLUMNS; i++) {
-    attr_sizes.emplace_back(8);
+    attr_sizes.emplace_back(MAX_NUM_OF_VERSIONS);
   }
 
   TERRIER_ASSERT(attr_sizes.size() == NUM_RESERVED_COLUMNS,

--- a/test/include/test_util/storage_test_util.h
+++ b/test/include/test_util/storage_test_util.h
@@ -273,7 +273,8 @@ class StorageTestUtil {
 
   template <class RowType>
   static bool ProjectionListAtOidsNone(const RowType *const row, const storage::ProjectionMap &oid_map,
-                                       const storage::BlockLayout &layout, const std::vector<catalog::col_oid_t> &oids) {
+                                       const storage::BlockLayout &layout,
+                                       const std::vector<catalog::col_oid_t> &oids) {
     for (const auto &oid : oids) {
       EXPECT_EQ(oid_map.find(oid), oid_map.end());
       if (oid_map.find(oid) != oid_map.end()) {

--- a/test/storage/sql_table_test.cpp
+++ b/test/storage/sql_table_test.cpp
@@ -437,10 +437,10 @@ class RandomSqlTableTestObject {
 
   // Structure that defines hashing and comparison operations for user's type.
   struct SlotHash {
-    // NOLINT
+    // NOLINTNEXTLINE
     static size_t hash(const storage::TupleSlot &slot) { return std::hash<storage::TupleSlot>{}(slot); }
 
-    // NOLINT
+    // NOLINTNEXTLINE
     static bool equal(const storage::TupleSlot &slot1, const storage::TupleSlot &slot2) { return slot1 == slot2; }
   };
 
@@ -455,7 +455,7 @@ class RandomSqlTableTestObject {
   std::vector<storage::TupleSlot> updated_slots_;
   // oldest to newest
   tbb::concurrent_hash_map<storage::TupleSlot, std::vector<TupleVersion>, SlotHash> tuple_versions_;
-  // NOLINT
+  // NOLINTNEXTLINE
   typedef tbb::concurrent_hash_map<storage::TupleSlot, std::vector<TupleVersion>, SlotHash>::accessor
       tuple_versions_accessor_;
 

--- a/test/storage/sql_table_test.cpp
+++ b/test/storage/sql_table_test.cpp
@@ -59,7 +59,9 @@ static std::unique_ptr<catalog::Schema> AddColumns(const catalog::Schema &schema
   }
 
   struct {
-    bool operator()(const catalog::Schema::Column &a, const catalog::Schema::Column &b) const { return a.Oid() < b.Oid(); }
+    bool operator()(const catalog::Schema::Column &a, const catalog::Schema::Column &b) const {
+      return a.Oid() < b.Oid();
+    }
   } column_less;
   std::sort(columns.begin(), columns.end(), column_less);
 

--- a/test/storage/sql_table_test.cpp
+++ b/test/storage/sql_table_test.cpp
@@ -258,9 +258,11 @@ class RandomSqlTableTestObject {
     return table_->Delete(common::ManagedPointer(txn), slot);
   }
 
-  void UpdateSchema(common::ManagedPointer<transaction::TransactionContext> txn,
+  bool UpdateSchema(common::ManagedPointer<transaction::TransactionContext> txn,
                     std::unique_ptr<catalog::Schema> schema, const storage::layout_version_t layout_version) {
-    if (txn != nullptr) table_->UpdateSchema(txn, *schema, layout_version);
+    if (txn != nullptr) {
+      if (!table_->UpdateSchema(txn, *schema, layout_version)) return false;
+    }
 
     auto columns = schema->GetColumns();
     std::vector<catalog::col_oid_t> oids;
@@ -272,6 +274,7 @@ class RandomSqlTableTestObject {
     schemas_.insert(std::make_pair(layout_version, std::unique_ptr<catalog::Schema>(std::move(schema))));
     pris_.insert(std::make_pair(layout_version, pri));
     buffers_.insert(std::make_pair(layout_version, common::AllocationUtil::AllocateAligned(pri.ProjectedRowSize())));
+    return true;
   }
 
   common::ManagedPointer<transaction::TransactionContext> NewTransaction(

--- a/test/test_util/sql_table_test_util.cpp
+++ b/test/test_util/sql_table_test_util.cpp
@@ -24,7 +24,7 @@ void RandomSqlTableTransaction::RandomInsert(Random *generator) {
   // Generate random insert
   auto initializer = sql_table_ptr->InitializerForProjectedRow(sql_table_metadata->col_oids_);
   auto *const record = txn_->StageWrite(database_oid, table_oid, initializer);
-  StorageTestUtil::PopulateRandomRow(record->Delta(), sql_table_ptr->tables_.begin()->second.layout_, 0.0, generator);
+  StorageTestUtil::PopulateRandomRow(record->Delta(), sql_table_ptr->tables_.begin()->layout_, 0.0, generator);
   record->SetTupleSlot(storage::TupleSlot(nullptr, 0));
   auto tuple_slot = sql_table_ptr->Insert(common::ManagedPointer(txn_), record);
 
@@ -57,7 +57,7 @@ void RandomSqlTableTransaction::RandomUpdate(Random *generator) {
       StorageTestUtil::RandomNonEmptySubset(sql_table_metadata->col_oids_, generator));
   auto *const record = txn_->StageWrite(database_oid, table_oid, initializer);
   record->SetTupleSlot(updated);
-  StorageTestUtil::PopulateRandomRow(record->Delta(), sql_table_ptr->tables_.begin()->second.layout_, 0.0, generator);
+  StorageTestUtil::PopulateRandomRow(record->Delta(), sql_table_ptr->tables_.begin()->layout_, 0.0, generator);
   auto result = sql_table_ptr->Update(common::ManagedPointer(txn_), record);
   aborted_ = !result;
 }
@@ -253,7 +253,7 @@ void LargeSqlTableTestObject::PopulateInitialTables(uint16_t num_databases, uint
       std::vector<storage::TupleSlot> inserted_tuples;
       for (uint32_t i = 0; i < num_tuples; i++) {
         auto *const redo = initial_txn_->StageWrite(database_oid, table_oid, initializer);
-        StorageTestUtil::PopulateRandomRow(redo->Delta(), sql_table->tables_.begin()->second.layout_, 0.0, generator);
+        StorageTestUtil::PopulateRandomRow(redo->Delta(), sql_table->tables_.begin()->layout_, 0.0, generator);
         const storage::TupleSlot inserted = sql_table->Insert(common::ManagedPointer(initial_txn_), redo);
         inserted_tuples.emplace_back(inserted);
       }


### PR DESCRIPTION
Use fixed size array to make concurrent read safe. Use atomic tracking index to guarantee no concurrent write to same dataversion. 
TODO: concurrent tests